### PR TITLE
Configure circular references

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ subprojects {
 	apply plugin: 'com.bmuschko.nexus'
 	sourceCompatibility = 1.8
 	targetCompatibility = 1.8
-	version = '0.5'
+	version = '0.51'
 	jar {
 		manifest {
 			attributes 'Implementation-Title': 'Gradle Quickstart', 'Implementation-Version': version

--- a/micro-core/build.gradle
+++ b/micro-core/build.gradle
@@ -11,7 +11,7 @@ modifyPom {
 
 		groupId 'com.aol.microservices'
 		artifactId 'microserver-core'
-		version '0.5'
+		version '0.51'
 		
 		scm {
 			url 'scm:git@github.com:aol/micro-server.git'

--- a/micro-core/src/main/java/com/aol/micro/server/config/Config.java
+++ b/micro-core/src/main/java/com/aol/micro/server/config/Config.java
@@ -38,6 +38,7 @@ public class Config {
 	private final String propertiesName;
 	private final ImmutableMap<String,List<String>> dataSources;
 	private final SSLProperties sslProperties;
+	private final boolean allowCircularReferences;
 	
 	
 	public Config() {
@@ -47,6 +48,8 @@ public class Config {
 		defaultDataSourceName="db";
 		propertiesName = "application.properties";
 		sslProperties = null;
+		allowCircularReferences = false;
+
 	}
 
 	private static volatile Config instance = null;

--- a/micro-core/src/main/java/com/aol/micro/server/spring/SpringApplicationConfigurator.java
+++ b/micro-core/src/main/java/com/aol/micro/server/spring/SpringApplicationConfigurator.java
@@ -36,7 +36,7 @@ class SpringApplicationConfigurator implements SpringBuilder {
 	
 		logger.debug("Configuring Spring");
 		AnnotationConfigWebApplicationContext rootContext = new AnnotationConfigWebApplicationContext();
-		rootContext.setAllowCircularReferences(false);
+		rootContext.setAllowCircularReferences(config.isAllowCircularReferences());
 		rootContext.register(classes);
 		
 		Optional<Package> basePackage = Stream.of(classes)

--- a/micro-core/src/main/java/com/aol/micro/server/spring/datasource/DataSourceBuilder.java
+++ b/micro-core/src/main/java/com/aol/micro/server/spring/datasource/DataSourceBuilder.java
@@ -7,7 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Builder;
 
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.commons.dbcp2.BasicDataSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -39,7 +39,7 @@ public class DataSourceBuilder {
 		if (!"org.hibernate.dialect.HSQLDialect".equals(env.getDialect())) {
 			ds.setTestOnBorrow(true);
 			ds.setValidationQuery("SELECT 1");
-			ds.setMaxActive(maxActive);
+			ds.setMaxTotal(maxActive);
 			ds.setMinEvictableIdleTimeMillis(1800000);
 			ds.setTimeBetweenEvictionRunsMillis(1800000);
 			ds.setNumTestsPerEvictionRun(3);

--- a/micro-core/src/test/java/com/aol/micro/server/config/MicroserverConfigurerTest.java
+++ b/micro-core/src/test/java/com/aol/micro/server/config/MicroserverConfigurerTest.java
@@ -49,7 +49,17 @@ public class MicroserverConfigurerTest {
 				hasItem(Integer.class));
 		
 	}
-	
+
+	@Test
+	public void circularReferences() {
+		Config config = configurer.buildConfig(MicroserverConfigurerTest.class);
+			assertFalse(config.isAllowCircularReferences());
+		config = configurer.buildConfig(MicroserverConfigurerTest.class)
+												.withAllowCircularReferences(true);
+
+		assertTrue(config.isAllowCircularReferences());
+
+	}
 	
 
 }

--- a/micro-tutorial/src/main/java/app1/simple/MyRestEndPoint.java
+++ b/micro-tutorial/src/main/java/app1/simple/MyRestEndPoint.java
@@ -62,7 +62,7 @@ public class MyRestEndPoint {
 	@Path("/create")
 	@ApiOperation(value = "Create db entity", response = String.class)
 	public String createEntity() {
-		dao.update("insert into t_jdbc VALUES (1,'hello','world',1)");
+		dao.getJdbc().update("insert into t_jdbc VALUES (1,'hello','world',1)");
 	
 		return "ok";
 	}
@@ -72,7 +72,7 @@ public class MyRestEndPoint {
 	@Path("/get")
 	@ApiOperation(value = "Query for single entity", response = Entity.class)
 	public Entity get() {
-		return dao.<Entity>queryForObject("select * from t_jdbc",new BeanPropertyRowMapper(Entity.class));
+		return dao.getJdbc().<Entity>queryForObject("select * from t_jdbc",new BeanPropertyRowMapper(Entity.class));
 	}
 	
 	@GET


### PR DESCRIPTION
Support for configuration of circular references to resolve  Issue #5 
By default they are disabled. 
- updates to get align DataSourceBuilder with dbcp jar version
- fixes to the tutorial to get jdbc object.