### PR TITLE
Changed gradle shadow plugin dependency version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 
 	dependencies {
 		classpath 'com.bmuschko:gradle-nexus-plugin:2.2'
-		classpath 'com.github.jengelman.gradle.plugins:shadow:1.1.1'
+		classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.0'
 	}
 }
 


### PR DESCRIPTION
Changing the dependency version to 1.2.0 allows Eclipse Gradle plugin to import de project.