### PR TITLE
make best guess of host and make it configurable

### DIFF
--- a/micro-core/src/main/java/com/aol/micro/server/module/Environment.java
+++ b/micro-core/src/main/java/com/aol/micro/server/module/Environment.java
@@ -1,11 +1,15 @@
 package com.aol.micro.server.module;
 
+import java.net.InetAddress;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
+import org.jooq.lambda.fi.util.function.CheckedSupplier;
+
+import com.aol.simple.react.exceptions.ExceptionSoftener;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 
@@ -34,10 +38,19 @@ public class Environment {
 		if (!modulePort.containsKey(module.getContext())) {
 			Map<String, ModuleBean> builder = Maps.newHashMap();
 			builder.putAll(modulePort);
-			builder.put(module.getContext(), ModuleBean.builder().port(getPort(module)).build());
+			builder.put(module.getContext(), ModuleBean.builder().host(getHost(module)).port(getPort(module)).build());
 			modulePort = ImmutableMap.copyOf(builder);
 		}
 
+	}
+
+	private String getHost(Module module) {
+		CheckedSupplier<String> s = ()->InetAddress.getLocalHost().getHostName();
+		try{
+			return Optional.ofNullable(properties.get(module.getContext() + ".host")).orElse(s.get()).toString();
+		}catch(Throwable e){
+			 throw new RuntimeException(e);
+		}
 	}
 
 	private int getPort(Module module) {

--- a/micro-core/src/test/java/com/aol/micro/server/module/EnvironmentTest.java
+++ b/micro-core/src/test/java/com/aol/micro/server/module/EnvironmentTest.java
@@ -1,8 +1,10 @@
 package com.aol.micro.server.module;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.Properties;
 
 import org.junit.Test;
@@ -36,5 +38,29 @@ public class EnvironmentTest {
 		Environment environment = new Environment(props);
 		environment.assureModule(() ->"context");
 		assertThat(environment.getModuleBean(()-> "context").getPort(), is(8081));
+	}
+	
+	@Test
+	public void testDefaultHost() throws UnknownHostException {
+		String host =InetAddress.getLocalHost().getHostName();
+		Environment environment = new Environment(new Properties());
+		environment.assureModule(() ->"context");
+		assertThat(environment.getModuleBean(()-> "context").getHost(), is(host));
+	}
+	@Test
+	public void testDefaultHostNotNull() throws UnknownHostException {
+		
+		Environment environment = new Environment(new Properties());
+		environment.assureModule(() ->"context");
+		assertThat(environment.getModuleBean(()-> "context").getHost(), is(not(nullValue())));
+	}
+	@Test
+	public void testHostOverride() throws UnknownHostException {
+		
+		Properties props = new Properties();
+		props.put("context.host", "overriden-host");
+		Environment environment = new Environment(props);
+		environment.assureModule(() ->"context");
+		assertThat(environment.getModuleBean(()-> "context").getHost(), is("overriden-host"));
 	}
 }


### PR DESCRIPTION
Related to this issue (https://github.com/aol/micro-server/issues/19) - will make best guess of host when creating Module metadata, and make it optionally configurable via application.properties.

The SwaggerInitializer uses the host information as part of the basePath property.