### PR TITLE
Adding cross domain filter to make swagger-ui working

### DIFF
--- a/micro-core/src/main/java/com/aol/micro/server/web/filter/CrossDomainFilter.java
+++ b/micro-core/src/main/java/com/aol/micro/server/web/filter/CrossDomainFilter.java
@@ -1,0 +1,42 @@
+package com.aol.micro.server.web.filter;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.stereotype.Component;
+
+import com.aol.micro.server.auto.discovery.FilterConfiguration;
+
+@Component(value = "crossDomainFilter")
+public class CrossDomainFilter implements Filter, FilterConfiguration {
+
+	@Override
+	public String[] getMapping() {
+		return new String[] { "/*" };
+	}
+
+	@Override
+	public void init(FilterConfig filterConfig) throws ServletException {
+
+	}
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+		HttpServletResponse resp = (HttpServletResponse) response;
+		resp.addHeader("Access-Control-Allow-Origin", "*");
+		resp.addHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT");
+		resp.addHeader("Access-Control-Allow-Headers", "X-Requested-With, Content-Type, X-Codingpedia");
+		chain.doFilter(request, response);
+	}
+
+	@Override
+	public void destroy() {
+	}
+}

--- a/micro-core/src/test/java/com/aol/micro/server/servers/CrossDomainFilterTest.java
+++ b/micro-core/src/test/java/com/aol/micro/server/servers/CrossDomainFilterTest.java
@@ -1,0 +1,47 @@
+package com.aol.micro.server.servers;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+import com.aol.micro.server.web.filter.CrossDomainFilter;
+
+public class CrossDomainFilterTest {
+
+	private CrossDomainFilter crossDomainFilter;
+
+	@Before
+	public void init() {
+		this.crossDomainFilter = new CrossDomainFilter();
+	}
+
+	@Test
+	public void testFilter() throws IOException, ServletException {
+
+		ServletRequest request = mock(ServletRequest.class);
+		HttpServletResponse response = mock(HttpServletResponse.class);
+		FilterChain filterChain = mock(FilterChain.class);
+
+		crossDomainFilter.doFilter(request, response, filterChain);
+
+		InOrder inOrder = Mockito.inOrder(response, filterChain);
+
+		inOrder.verify(response, times(1)).addHeader("Access-Control-Allow-Origin", "*");
+		inOrder.verify(response, times(1)).addHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT");
+		inOrder.verify(response, times(1)).addHeader("Access-Control-Allow-Headers", "X-Requested-With, Content-Type, X-Codingpedia");
+
+		inOrder.verify(filterChain, times(1)).doFilter(request, response);
+
+	}
+}


### PR DESCRIPTION
Swagger-ui ( https://github.com/swagger-api/swagger-ui ) needs to have access-control-origin enabled in order to access the rest documentation