### PR TITLE
Blacklisting spring classes support was added

### DIFF
--- a/micro-core/src/main/java/com/aol/micro/server/config/Microserver.java
+++ b/micro-core/src/main/java/com/aol/micro/server/config/Microserver.java
@@ -24,7 +24,10 @@ public @interface Microserver {
 	 */
 	Class[] classes() default {};
 
-	
+	/** @return blacklist of classes that should be excluded from spring context
+	 * 
+	 */
+	Class[] blacklistedClasses() default {};
 
 	/**
 	 * @return Property file name

--- a/micro-core/src/main/java/com/aol/micro/server/config/MicroserverConfigurer.java
+++ b/micro-core/src/main/java/com/aol/micro/server/config/MicroserverConfigurer.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.pcollections.HashTreePMap;
@@ -48,6 +49,8 @@ public class MicroserverConfigurer implements Configurer {
 
 	private List<Class> buildClasses(Class class1, Microserver microserver) {
 		List<Class> classes = new ArrayList();
+		Set<Class> blackList = Arrays.stream(microserver.blacklistedClasses()).collect(Collectors.toSet());
+
 		classes.add(class1);
 		if (microserver.classes() != null)
 			classes.addAll(Arrays.asList(microserver.classes()));
@@ -55,6 +58,6 @@ public class MicroserverConfigurer implements Configurer {
 		if(modules.size()>0)
 			classes.addAll(SequenceM.fromStream(modules.stream()).flatMap(module -> module.springClasses().stream()).toList());
 		
-		return classes;
+		return classes.stream().filter(clazz -> !blackList.contains(clazz)).collect(Collectors.toList());
 	}
 }

--- a/micro-core/src/test/java/com/aol/micro/server/config/MicroserverConfigurerTest.java
+++ b/micro-core/src/test/java/com/aol/micro/server/config/MicroserverConfigurerTest.java
@@ -2,6 +2,7 @@ package com.aol.micro.server.config;
 
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -9,7 +10,9 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 @Microserver(propertiesName = "test!", instancePropertiesName = "test2!",serviceTypePropertiesName = "servicetType!", 
-			properties = { "hello", "world" }, entityScan = { "packages" }, classes = { Integer.class })
+			properties = { "hello", "world" }, entityScan = { "packages" }, classes = { String.class, Integer.class }, 
+			blacklistedClasses = {String.class})
+
 public class MicroserverConfigurerTest {
 	MicroserverConfigurer configurer = new MicroserverConfigurer();
 
@@ -48,6 +51,14 @@ public class MicroserverConfigurerTest {
 		Config config = configurer.buildConfig(MicroserverConfigurerTest.class);
 		System.out.println(config.getClasses());
 		assertThat(config.getClasses(), hasItem(Integer.class));
+
+	}
+	
+	@Test
+	public void blacklistedClasses() {
+		Config config = configurer.buildConfig(MicroserverConfigurerTest.class);
+		System.out.println(config.getClasses());
+		assertThat(config.getClasses(), not(hasItem(String.class)));
 
 	}
 


### PR DESCRIPTION
Right now Microserver load all of classes that are in "classes" or "basePackages" attribute. Sometime it is required to blacklist some of the classes (for example in case of multiple asynchronous spring configurations). This pull request add blacklistedClasses attribute that should contain classes, that would be filtered from sprint class list.   