### PR TITLE
capture ip address for application register

### DIFF
--- a/micro-application-register/build.gradle
+++ b/micro-application-register/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 	compile project(':micro-core')
 	compile project(':micro-reactive')
 	compile project(':micro-client')
+	compile project(':micro-ip-tracker')
 	testCompile project(':micro-grizzly-with-jersey')
 	
 }

--- a/micro-application-register/readme.md
+++ b/micro-application-register/readme.md
@@ -46,3 +46,15 @@ Functionality
     service.registry.entry.max.live:43200000
     service.registry.dir:java.io.tmpdir/services
     service.registry.url: url to register services on (http://hostname:port/context)
+    
+### Configure a custom host address
+
+Use the property, host.address to set the host address (otherwise InetAddress.getLocalHost().getHostName() is used, which may cause some problems when using containers).
+
+	host.address=custom.host.addrress
+
+### Use caller ip
+
+To configure the application register to use the callers ip (rather than the senders hostname), the sender should configure host.address as follows 
+
+	host.address=use-ip

--- a/micro-application-register/src/main/java/com/aol/micro/server/application/registry/ApplicationRegisterImpl.java
+++ b/micro-application-register/src/main/java/com/aol/micro/server/application/registry/ApplicationRegisterImpl.java
@@ -40,7 +40,7 @@ public class ApplicationRegisterImpl implements ApplicationRegister {
 							.getModule().getContext(), null)).collect(Collectors.toList()));
 			logger.info("Registered application {} ", application);
 		} catch (UnknownHostException e) {
-			ExceptionSoftener.throwSoftenedException(e);
+			throw ExceptionSoftener.throwSoftenedException(e);
 		}
 	}
 }

--- a/micro-application-register/src/main/java/com/aol/micro/server/application/registry/Register.java
+++ b/micro-application-register/src/main/java/com/aol/micro/server/application/registry/Register.java
@@ -3,14 +3,17 @@ package com.aol.micro.server.application.registry;
 import java.io.File;
 import java.io.IOException;
 
+import lombok.val;
+
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import com.aol.micro.server.ErrorCode;
+import com.aol.micro.server.ip.tracker.*;
 import com.aol.micro.server.rest.jackson.JacksonUtil;
+
 
 @Component
 public class Register {
@@ -30,7 +33,11 @@ public class Register {
 
 		File file = new File(dir, entry.getHostname() + "-" + entry.getModule() + "-" + entry.getUuid());
 		try {
-			FileUtils.writeStringToFile(file, JacksonUtil.serializeToJson(entry));
+			final RegisterEntry entryToUse = "use-ip".equals(entry.getHostname()) ? 
+									entry.withHostname(QueryIPRetriever.getIpAddress()) : entry;
+			
+			
+			FileUtils.writeStringToFile(file, JacksonUtil.serializeToJson(entryToUse));
 		} catch (IOException e) {
 			logger.error("Error registering service to disk {}", JacksonUtil.serializeToJson(entry));
 		}

--- a/micro-application-register/src/test/java/app/registry/com/aol/micro/server/RegistryAppRunner.java
+++ b/micro-application-register/src/test/java/app/registry/com/aol/micro/server/RegistryAppRunner.java
@@ -1,10 +1,10 @@
 package app.registry.com.aol.micro.server;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-import java.io.IOException;
-import java.util.Properties;
+import java.util.Date;
 import java.util.concurrent.ExecutionException;
 
 import org.junit.After;
@@ -12,8 +12,10 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.aol.micro.server.MicroserverApp;
+import com.aol.micro.server.application.registry.RegisterEntry;
 import com.aol.micro.server.config.Microserver;
-import com.aol.micro.server.spring.properties.PropertyFileConfig;
+import com.aol.micro.server.rest.client.nio.AsyncRestClient;
+import com.aol.micro.server.rest.jackson.JacksonUtil;
 import com.aol.micro.server.testing.RestAgent;
 
 @Microserver(properties={"service.registry.url","http://localhost:8080/registry-app"})
@@ -21,7 +23,7 @@ public class RegistryAppRunner {
 
 
 	RestAgent rest = new RestAgent();
-	
+	private final AsyncRestClient restAsync = new AsyncRestClient(100,2000);
 	MicroserverApp server;
 	@Before
 	public void startServer(){
@@ -44,9 +46,24 @@ public class RegistryAppRunner {
 		assertThat(rest.post("http://localhost:8080/registry-app/service-registry/schedule"),is("{\"status\":\"success\"}"));
 		Thread.sleep(1000);
 		assertThat(rest.getJson("http://localhost:8080/registry-app/service-registry/list"),containsString("[{\"port\":8080,"));
+		
+		sendPing(new RegisterEntry(8081,"use-ip","hello","world", new Date()));
+		Thread.sleep(1000);
+		System.out.println(rest.getJson("http://localhost:8080/registry-app/service-registry/list"));
+		assertThat(rest.getJson("http://localhost:8080/registry-app/service-registry/list"),containsString("[{\"port\":8081,"));
+		
 	
 	}
 	
+	private void sendPing(RegisterEntry entry) {
+		
+		try {
+
+			restAsync.post("http://localhost:8080/registry-app/service-registry/register", JacksonUtil.serializeToJson(entry)).join();
+		} catch (Exception e) {
+
+		}
+	}
 	
 	
 	


### PR DESCRIPTION
This allows the host.address property on the sender to tell the reciever to override the senders host address with their captured IP address.