### PR TITLE
Curator fix with reentrant locking

### DIFF
--- a/micro-curator/src/integration/java/com/aol/micro/server/curator/lock/IntegrationTest.java
+++ b/micro-curator/src/integration/java/com/aol/micro/server/curator/lock/IntegrationTest.java
@@ -59,6 +59,7 @@ public class IntegrationTest {
 		
 		DistributedLockService lock = provider.getDistributedLock(1000);
 		Assert.assertTrue(lock.tryLock(lockName));
+		Assert.assertTrue(lock.tryLock(lockName));
 		DistributedLockService lock2 = provider.getDistributedLock(1000);
 		Assert.assertFalse(lock2.tryLock(lockName));
 	}

--- a/micro-curator/src/main/java/com/aol/micro/server/curator/lock/DistributedLockServiceCuratorImpl.java
+++ b/micro-curator/src/main/java/com/aol/micro/server/curator/lock/DistributedLockServiceCuratorImpl.java
@@ -58,7 +58,7 @@ public class DistributedLockServiceCuratorImpl implements DistributedLockService
 
 	private boolean acquire() {
 		try {
-			return curatorLock.acquire(timeout, TimeUnit.MILLISECONDS);
+			return acquired ? acquired : curatorLock.acquire(timeout, TimeUnit.MILLISECONDS);
 		} catch (Exception e) {
 			return false;
 		}


### PR DESCRIPTION
Before that fix you couldn't acquire same lock twice in same instance of object.