### PR TITLE
Blacklisted classes patch

### DIFF
--- a/micro-core/src/main/java/com/aol/micro/server/MicroserverApp.java
+++ b/micro-core/src/main/java/com/aol/micro/server/MicroserverApp.java
@@ -53,7 +53,7 @@ public class MicroserverApp {
 		Class c =extractClass();
 		springContext = new SpringContextFactory(new MicroserverConfigurer().buildConfig(
 				c), extractClass(),
-				new MicroserverConfigurer().getClasses(c,modules[0].getSpringConfigurationClasses()))
+				modules[0].getSpringConfigurationClasses())
 				.createSpringContext();
 
 	}
@@ -72,7 +72,7 @@ public class MicroserverApp {
 		this.modules = Arrays.asList(modules);
 		springContext = new SpringContextFactory(
 				new MicroserverConfigurer().buildConfig(c), c,
-				new MicroserverConfigurer().getClasses(c,modules[0].getSpringConfigurationClasses()))
+				modules[0].getSpringConfigurationClasses())
 				.createSpringContext();
 
 	}

--- a/micro-core/src/main/java/com/aol/micro/server/config/MicroserverConfigurer.java
+++ b/micro-core/src/main/java/com/aol/micro/server/config/MicroserverConfigurer.java
@@ -49,7 +49,6 @@ public class MicroserverConfigurer implements Configurer {
 
 	private List<Class> buildClasses(Class class1, Microserver microserver) {
 		List<Class> classes = new ArrayList();
-		Set<Class> blackList = Arrays.stream(microserver.blacklistedClasses()).collect(Collectors.toSet());
 
 		classes.add(class1);
 		if (microserver.classes() != null)
@@ -58,14 +57,7 @@ public class MicroserverConfigurer implements Configurer {
 		if(modules.size()>0)
 			classes.addAll(SequenceM.fromStream(modules.stream()).flatMap(module -> module.springClasses().stream()).toList());
 		
-		return classes.stream().filter(clazz -> !blackList.contains(clazz)).collect(Collectors.toList());
+		return classes;
 	}
 
-	public Set<Class> getClasses(Class class1,Set<Class> coreClasses) {
-		Microserver microserver = (Microserver) class1.getAnnotation(Microserver.class);
-		if(microserver==null)
-			return coreClasses;
-		Set<Class> blackList = Arrays.stream(microserver.blacklistedClasses()).collect(Collectors.toSet());
-		return coreClasses.stream().filter(clazz -> !blackList.contains(clazz)).collect(Collectors.toSet());
-	}
 }

--- a/micro-core/src/main/java/com/aol/micro/server/spring/SpringContextFactory.java
+++ b/micro-core/src/main/java/com/aol/micro/server/spring/SpringContextFactory.java
@@ -2,6 +2,7 @@ package com.aol.micro.server.spring;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -39,8 +40,12 @@ public class SpringContextFactory {
 		if(c != null) {
 			s.add(c);
 			Microserver microserver = (Microserver) c.getAnnotation(Microserver.class);
-			Set<Class> blacklistedClasses = Arrays.stream(microserver.blacklistedClasses()).collect(Collectors.toSet());
-			s = s.stream().filter(clazz -> !blacklistedClasses.contains(clazz)).collect(Collectors.toSet());
+			final Set<Class> immutableS = s;
+			
+			s = Optional.ofNullable(microserver).flatMap(ms -> Optional.ofNullable(ms.blacklistedClasses())).map(bl -> {
+				Set<Class> blacklistedClasses = Arrays.stream(bl).collect(Collectors.toSet());
+				return immutableS.stream().filter(clazz -> !blacklistedClasses.contains(clazz)).collect(Collectors.toSet());
+			}).orElse(immutableS);
 		}
 		
 		this.classes = HashTreePSet.from(s);

--- a/micro-core/src/main/java/com/aol/micro/server/spring/SpringContextFactory.java
+++ b/micro-core/src/main/java/com/aol/micro/server/spring/SpringContextFactory.java
@@ -37,16 +37,14 @@ public class SpringContextFactory {
 		Set<Class> s = new HashSet<Class>(classes);
 		s.addAll(config.getClasses());
 		
-		if(c != null) {
-			s.add(c);
-			Microserver microserver = (Microserver) c.getAnnotation(Microserver.class);
-			final Set<Class> immutableS = s;
-			
-			s = Optional.ofNullable(microserver).flatMap(ms -> Optional.ofNullable(ms.blacklistedClasses())).map(bl -> {
-				Set<Class> blacklistedClasses = Arrays.stream(bl).collect(Collectors.toSet());
-				return immutableS.stream().filter(clazz -> !blacklistedClasses.contains(clazz)).collect(Collectors.toSet());
-			}).orElse(immutableS);
-		}
+		s.add(c);
+		Microserver microserver = (Microserver) c.getAnnotation(Microserver.class);
+		final Set<Class> immutableS = s;
+		
+		s = Optional.ofNullable(microserver).flatMap(ms -> Optional.ofNullable(ms.blacklistedClasses())).map(bl -> {
+			Set<Class> blacklistedClasses = Arrays.stream(bl).collect(Collectors.toSet());
+			return immutableS.stream().filter(clazz -> !blacklistedClasses.contains(clazz)).collect(Collectors.toSet());
+		}).orElse(immutableS);
 		
 		this.classes = HashTreePSet.from(s);
 		this.config = config;
@@ -57,10 +55,6 @@ public class SpringContextFactory {
 				.map(Plugin::springBuilder)
 				.findFirst()
 				.orElse(new SpringApplicationConfigurator());
-	}
-	
-	public SpringContextFactory(Config config, Set<Class> classes) {
-		this(config, null, classes);
 	}
 
 	public ApplicationContext createSpringContext() {

--- a/micro-core/src/main/java/com/aol/micro/server/spring/SpringContextFactory.java
+++ b/micro-core/src/main/java/com/aol/micro/server/spring/SpringContextFactory.java
@@ -1,11 +1,9 @@
 package com.aol.micro.server.spring;
 
+import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
-
-import lombok.AllArgsConstructor;
-import lombok.experimental.Wither;
+import java.util.stream.Collectors;
 
 import org.pcollections.HashTreePSet;
 import org.pcollections.PSet;
@@ -18,8 +16,11 @@ import com.aol.cyclops.sequence.SequenceM;
 import com.aol.micro.server.ErrorCode;
 import com.aol.micro.server.Plugin;
 import com.aol.micro.server.PluginLoader;
-import com.aol.micro.server.auto.discovery.RestResource;
 import com.aol.micro.server.config.Config;
+import com.aol.micro.server.config.Microserver;
+
+import lombok.AllArgsConstructor;
+import lombok.experimental.Wither;
 
 
 @AllArgsConstructor
@@ -32,9 +33,16 @@ public class SpringContextFactory {
 	private final SpringBuilder springBuilder;
 	
 	public SpringContextFactory(Config config, Class c, Set<Class> classes){
-		Set s = new HashSet(classes);
-		s.add(c);
+		Set<Class> s = new HashSet<Class>(classes);
 		s.addAll(config.getClasses());
+		
+		if(c != null) {
+			s.add(c);
+			Microserver microserver = (Microserver) c.getAnnotation(Microserver.class);
+			Set<Class> blacklistedClasses = Arrays.stream(microserver.blacklistedClasses()).collect(Collectors.toSet());
+			s = s.stream().filter(clazz -> !blacklistedClasses.contains(clazz)).collect(Collectors.toSet());
+		}
+		
 		this.classes = HashTreePSet.from(s);
 		this.config = config;
 		
@@ -47,16 +55,7 @@ public class SpringContextFactory {
 	}
 	
 	public SpringContextFactory(Config config, Set<Class> classes) {
-		Set s = new HashSet(classes);
-		s.addAll(config.getClasses());
-		this.classes =  HashTreePSet.from(s);
-		this.config=config;
-		springBuilder = SequenceM
-				.fromStream(PluginLoader.INSTANCE.plugins.get().stream())
-				.filter(m -> m.springBuilder() != null)
-				.map(Plugin::springBuilder)
-				.findFirst()
-				.orElse(new SpringApplicationConfigurator());
+		this(config, null, classes);
 	}
 
 	public ApplicationContext createSpringContext() {

--- a/micro-core/src/test/java/com/aol/micro/server/config/MicroserverConfigurerTest.java
+++ b/micro-core/src/test/java/com/aol/micro/server/config/MicroserverConfigurerTest.java
@@ -54,13 +54,6 @@ public class MicroserverConfigurerTest {
 
 	}
 	
-	@Test
-	public void blacklistedClasses() {
-		Config config = configurer.buildConfig(MicroserverConfigurerTest.class);
-		System.out.println(config.getClasses());
-		assertThat(config.getClasses(), not(hasItem(String.class)));
-
-	}
 
 	@Test
 	public void selfClass() {

--- a/micro-core/src/test/java/com/aol/micro/server/spring/SpringContextFactoryTest.java
+++ b/micro-core/src/test/java/com/aol/micro/server/spring/SpringContextFactoryTest.java
@@ -1,0 +1,44 @@
+package com.aol.micro.server.spring;
+
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.aol.micro.server.config.Config;
+import com.aol.micro.server.config.Microserver;
+
+/**
+ * Any new classes shoud be added into blackListedClasses for test to pass until proper solution with
+ * matching varargs will be found
+ */
+
+@Microserver(blacklistedClasses = {Integer.class, SpringContextFactoryTest.class})
+public class SpringContextFactoryTest {
+
+
+	@SuppressWarnings("rawtypes")
+	@Test
+	public void blacklisting() {
+						
+		SpringBuilder springBuilder = mock(SpringBuilder.class);
+		
+		Set<Class> classes = new HashSet<>();
+		classes.add(Integer.class);
+		classes.add(String.class);
+		Config config = Config.instance().withBasePackages(new String[] {"com.aol.micro.server.spring"}).set();
+		new SpringContextFactory(config ,this.getClass(), classes).withSpringBuilder(springBuilder).createSpringContext();
+	    ArgumentCaptor<Class> varArgs = ArgumentCaptor.forClass(Class.class);
+		verify(springBuilder).createSpringApp(anyObject(), varArgs.capture());
+		Assert.assertTrue(varArgs.getAllValues().contains(String.class));
+		Assert.assertFalse(varArgs.getAllValues().contains(Integer.class));
+
+	}
+	
+}


### PR DESCRIPTION
Blacklisting logic was moved to SpringContextFactory to remove redundant calls and simplify filtering.