### PR TITLE
Jackson feature initialization order fixed

### DIFF
--- a/micro-jackson-configuration/src/main/java/com/aol/micro/server/rest/jackson/JacksonFeature.java
+++ b/micro-jackson-configuration/src/main/java/com/aol/micro/server/rest/jackson/JacksonFeature.java
@@ -26,10 +26,9 @@ public class JacksonFeature implements Feature {
 		});
        
         
-        context.register(JacksonJaxbJsonProvider.class, MessageBodyReader.class, MessageBodyWriter.class);
         JacksonJaxbJsonProvider provider = new JacksonJaxbJsonProvider();
      		provider.setMapper(JacksonUtil.getMapper());
-            context.register(provider);
+            context.register(provider, new Class[]{MessageBodyReader.class, MessageBodyWriter.class});
      
         return true;
     }


### PR DESCRIPTION
There was issue in jackson feature initialization. We have class `JacksonFeature` in microserver which configure jackson to work with microserver. It use two call to register json providers
```
context.register(JacksonJaxbJsonProvider.class, MessageBodyReader.class, MessageBodyWriter.c
lass);
//few lines below
context.register(provider);
```
but provider has class `JacksonJaxbJsonProvider`, so jersey decline this registration due to

>Any subsequent registration attempts for a component type, for which a class or instance-based registration already exists in the system MUST be rejected by the JAX-RS implementation and a warning SHOULD be raised to inform the user about the rejected registration. 
http://docs.oracle.com/javaee/7/api/javax/ws/rs/core/Configurable.html#register-java.lang.Object-