### PR TITLE
HttpClientErrorException now have body

### DIFF
--- a/micro-client/src/main/java/com/aol/micro/server/rest/client/nio/NIORestClient.java
+++ b/micro-client/src/main/java/com/aol/micro/server/rest/client/nio/NIORestClient.java
@@ -18,6 +18,7 @@ import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.util.concurrent.ListenableFutureCallback;
 import org.springframework.web.client.AsyncRequestCallback;
 import org.springframework.web.client.AsyncRestTemplate;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.ResponseExtractor;
 import org.springframework.web.client.RestClientException;
 
@@ -254,7 +255,12 @@ public class NIORestClient {
 
 			@Override
 			public void onFailure(Throwable t) {
-				completable.completeExceptionally(t);
+				if(t instanceof HttpClientErrorException) {
+					String message = ((HttpClientErrorException)t).getResponseBodyAsString();
+					completable.completeExceptionally(new IllegalArgumentException(message, t));
+				} else {
+					completable.completeExceptionally(t);
+				}
 			}
 		});
 		return completable;


### PR DESCRIPTION
Before that update response body of all exceptions weren't returned to GeneralExceptionMapper. I suggest this fix as temporary solution. Better way would be to add custom user-overriden exception processors to GeneralExceptionMapper.