### PR TITLE
Active events value fix

### DIFF
--- a/micro-events/src/main/java/com/aol/micro/server/events/ActiveEvents.java
+++ b/micro-events/src/main/java/com/aol/micro/server/events/ActiveEvents.java
@@ -45,9 +45,9 @@ public class ActiveEvents<T extends BaseEventInfo> {
 		Long time = System.currentTimeMillis();
 		DateFormat format = new SimpleDateFormat("yyyy.MM.dd 'at' HH:mm:ss z");
 		String formatted = format.format(time);
-		Long change = Runtime.getRuntime().freeMemory() - Optional.ofNullable(event)
-																.map(e->e.getFreeMemory())
-																.orElse(0l);
+		String change = Optional.ofNullable(event).map(e -> 
+			Long.toString(Runtime.getRuntime().freeMemory() - e.getFreeMemory())).orElse("unknown");
+				
 		return ImmutableMap.builder().putAll(data)
 				.putAll(ImmutableMap.of("event",event,"completed",time,"completed-formated",formatted,"time-taken",time-event.getStartedAt()
 						,"memory-change",change )).build();


### PR DESCRIPTION
In case on null event we'll log free memory as number of used memory which is incorrect. Behavior changed to report "unknown" amount of memory.