### PR TITLE
Make Jersey ServerProperties configurable thourhg Module interface

### DIFF
--- a/micro-core/src/main/java/com/aol/micro/server/Plugin.java
+++ b/micro-core/src/main/java/com/aol/micro/server/Plugin.java
@@ -18,7 +18,6 @@ import javax.ws.rs.core.FeatureContext;
 import com.aol.micro.server.rest.RestConfiguration;
 import com.aol.micro.server.servers.ServerApplicationFactory;
 import com.aol.micro.server.servers.model.ServerData;
-import com.aol.micro.server.spring.SpringApplicationConfigurator;
 import com.aol.micro.server.spring.SpringBuilder;
 import com.aol.micro.server.spring.SpringDBConfig;
 import com.aol.micro.server.utility.HashMapBuilder;
@@ -124,5 +123,12 @@ public interface Plugin {
 	 */
 	default List<String> providers(){
 		return new ArrayList<>();
+	}
+	
+	/**
+	 * @return Jersey server properties for this plugin
+	 */
+	default Map<String, Object> getServerProperties() {		
+		return new HashMap<>();		
 	}
 }

--- a/micro-core/src/main/java/com/aol/micro/server/module/Module.java
+++ b/micro-core/src/main/java/com/aol/micro/server/module/Module.java
@@ -29,6 +29,10 @@ import com.aol.micro.server.servers.model.ServerData;
 
 public interface Module {
 	
+	default Map<String, Object> getServerProperties() {		
+		return new HashMap<>();		
+	}
+	
 	default <T> Consumer<WebServerProvider<T>> getServerConfigManager(){
 		return server->{};
 	}

--- a/micro-jersey/src/main/java/com/aol/micro/server/rest/jersey/JerseySpringIntegrationContextListener.java
+++ b/micro-jersey/src/main/java/com/aol/micro/server/rest/jersey/JerseySpringIntegrationContextListener.java
@@ -24,7 +24,7 @@ public class JerseySpringIntegrationContextListener implements ServletContextLis
 		JerseyRestApplication.getPackages().put(serverData.getModule().getContext(), serverData.getModule().getDefaultJaxRsPackages());
 		JerseyRestApplication.getResourcesClasses().put(serverData.getModule().getContext(), serverData.getModule().getDefaultResources());
 		JerseyRestApplication.getResourceConfigManager().put(serverData.getModule().getContext(), serverData.getModule().getResourceConfigManager());
-
+		JerseyRestApplication.getServerPropertyMap().put(serverData.getModule().getContext(), serverData.getModule().getServerProperties());
 	}
 
 }

--- a/micro-jersey/src/test/java/com/aol/micro/server/rest/jersey/JerseyRestApplicationTest.java
+++ b/micro-jersey/src/test/java/com/aol/micro/server/rest/jersey/JerseyRestApplicationTest.java
@@ -7,12 +7,12 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.stream.Collectors;
 
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-
 
 import com.aol.micro.server.rest.jackson.JacksonFeature;
 import com.aol.micro.server.servers.ServerThreadLocalVariables;
@@ -25,16 +25,13 @@ public class JerseyRestApplicationTest {
 		JerseyRestApplication.getResourcesMap().put(Thread.currentThread().getName(), Arrays.asList(new ServletStatusResource()));
 		JerseyRestApplication.getPackages().put(Thread.currentThread().getName(), Arrays.asList());
 		JerseyRestApplication.getResourcesClasses().put(Thread.currentThread().getName(), Arrays.asList(JacksonFeature.class));
+		JerseyRestApplication.getServerPropertyMap().put(Thread.currentThread().getName(), new HashMap<>());
 	}
 
 		@Test
-		public void testDefaultConstructor() {
-			
-			
+		public void testDefaultConstructor() {			
 			JerseyRestApplication app = new JerseyRestApplication();
-			assertTrue(app.isRegistered(ServletStatusResource.class));
-			
-				
+			assertTrue(app.isRegistered(ServletStatusResource.class));				
 			assertThat(	app.getApplication().getClasses().stream().map(c -> c.getName()).collect(Collectors.toSet()),hasItem("com.aol.micro.server.rest.jackson.JacksonFeature".intern()));
 			
 		}
@@ -53,7 +50,7 @@ public class JerseyRestApplicationTest {
 		public void testConstructor() {
 			JerseyRestApplication.getResourcesMap().clear();
 			JerseyRestApplication app = new JerseyRestApplication(Arrays.asList(new ServletStatusResource()),
-					Arrays.asList(),Arrays.asList(JacksonFeature.class));
+					Arrays.asList(),Arrays.asList(JacksonFeature.class), new HashMap<>());
 			assertThat(app.getApplication().getClasses().size(),is(1));
 			assertTrue(app.isRegistered(ServletStatusResource.class));
 		}


### PR DESCRIPTION
Once ServerProperties are configurable, for example, applications can provide their own wadl generator by using jersey.config.server.wadl.generatorConfig