### PR TITLE
Implementation will not include all RestResource implementing classes…

### DIFF
--- a/micro-core/src/main/java/com/aol/micro/server/module/ConfigurableModule.java
+++ b/micro-core/src/main/java/com/aol/micro/server/module/ConfigurableModule.java
@@ -5,6 +5,7 @@ import static com.aol.micro.server.utility.UsefulStaticMethods.concat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -23,6 +24,7 @@ import lombok.experimental.Wither;
 import org.pcollections.ConsPStack;
 import org.pcollections.HashTreePSet;
 
+import com.aol.micro.server.auto.discovery.CommonRestResource;
 import com.aol.micro.server.servers.model.ServerData;
 import com.aol.micro.server.utility.HashMapBuilder;
 
@@ -99,7 +101,7 @@ public class ConfigurableModule implements Module{
 	@Override
 	public List<Class> getRestResourceClasses() {
 		if(restResourceClasses!=null)
-			return  ConsPStack.from(concat(restResourceClasses, extract(() -> Module.super.getRestResourceClasses())));
+			return  ConsPStack.from(concat(restResourceClasses, extract(() -> Collections.singletonList(CommonRestResource.class))));
 		
 		return Module.super.getRestResourceClasses();
 	}

--- a/micro-core/src/test/java/com/aol/micro/server/module/ConfigurableModuleTest.java
+++ b/micro-core/src/test/java/com/aol/micro/server/module/ConfigurableModuleTest.java
@@ -25,6 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.pcollections.HashTreePSet;
 
+import com.aol.micro.server.auto.discovery.CommonRestResource;
 import com.aol.micro.server.auto.discovery.Rest;
 import com.aol.micro.server.auto.discovery.RestResource;
 import com.aol.micro.server.servers.model.ServerData;
@@ -129,7 +130,7 @@ public class ConfigurableModuleTest {
 	}
 	@Test
 	public void testGetRestResourceClasses() {
-		assertThat(module.getRestResourceClasses(),hasItem(RestResource.class));
+		assertThat(module.getRestResourceClasses(),hasItem(CommonRestResource.class));
 	}
 
 	@Test


### PR DESCRIPTION
For example if we have two micro-server projects coupled together in one jar, both of them have their own resources all of them are implementing RestResource (each of which trough own interface). If we will use ConfigurableModule it will add everything that implement RestResource to both of applications. It can cause security and stability issues. This fix should only allow classes implementing CommonRestResource.