### PR TITLE
Cleanup bean for s3. Will clean required folder on startup if enabled

### DIFF
--- a/micro-s3/src/main/java/com/aol/micro/server/s3/CleanupFileVisitor.java
+++ b/micro-s3/src/main/java/com/aol/micro/server/s3/CleanupFileVisitor.java
@@ -1,0 +1,35 @@
+package com.aol.micro.server.s3;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+public class CleanupFileVisitor extends SimpleFileVisitor<Path> {
+
+	private final Path tempDirectory;
+	
+	public CleanupFileVisitor(Path directory) {
+		this.tempDirectory = directory;
+	}
+	
+	@Override
+	public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+		Files.delete(file);
+		return FileVisitResult.CONTINUE;
+	}
+
+	@Override
+	public FileVisitResult postVisitDirectory(Path dir, IOException e) throws IOException {
+		if (e == null) {
+			if(!dir.equals(tempDirectory)) {
+				Files.delete(dir);
+			}
+			return FileVisitResult.CONTINUE;
+		} else {
+			throw e;
+		}
+	}
+}

--- a/micro-s3/src/main/java/com/aol/micro/server/s3/DirectoryCleaner.java
+++ b/micro-s3/src/main/java/com/aol/micro/server/s3/DirectoryCleaner.java
@@ -1,0 +1,35 @@
+package com.aol.micro.server.s3;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DirectoryCleaner {
+
+	private final String temporaryDirectory;
+	private final boolean cleanupOnStart;
+
+	@Autowired
+	public DirectoryCleaner(@Value("${s3.temp.dir:#{null}") String temporaryDirectory,
+			@Value("${s3.temp.cleanupOnStart:false") boolean cleanupOnStart) {
+		this.temporaryDirectory = temporaryDirectory;
+		this.cleanupOnStart = cleanupOnStart;
+	}
+
+	@PostConstruct
+	public void clean() throws IOException {
+		if (cleanupOnStart) {
+			Path directory = FileSystems.getDefault().getPath(temporaryDirectory);
+			Files.walkFileTree(directory, new CleanupFileVisitor(directory));
+		}
+	}
+
+}

--- a/micro-s3/src/main/java/com/aol/micro/server/s3/DirectoryCleaner.java
+++ b/micro-s3/src/main/java/com/aol/micro/server/s3/DirectoryCleaner.java
@@ -19,7 +19,7 @@ public class DirectoryCleaner {
 
 	@Autowired
 	public DirectoryCleaner(@Value("${s3.temp.dir:#{null}") String temporaryDirectory,
-			@Value("${s3.temp.cleanupOnStart:false") boolean cleanupOnStart) {
+			@Value("${s3.temp.clean.on.start:false") boolean cleanupOnStart) {
 		this.temporaryDirectory = temporaryDirectory;
 		this.cleanupOnStart = cleanupOnStart;
 	}

--- a/micro-s3/src/main/java/com/aol/micro/server/s3/DirectoryCleaner.java
+++ b/micro-s3/src/main/java/com/aol/micro/server/s3/DirectoryCleaner.java
@@ -1,5 +1,6 @@
 package com.aol.micro.server.s3;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -15,18 +16,15 @@ import org.springframework.stereotype.Component;
 public class DirectoryCleaner {
 
 	private final String temporaryDirectory;
-	private final boolean cleanupOnStart;
 
 	@Autowired
-	public DirectoryCleaner(@Value("${s3.temp.dir:#{null}") String temporaryDirectory,
-			@Value("${s3.temp.clean.on.start:false") boolean cleanupOnStart) {
+	public DirectoryCleaner(@Value("${s3.temp.dir:#{null}") String temporaryDirectory) {
 		this.temporaryDirectory = temporaryDirectory;
-		this.cleanupOnStart = cleanupOnStart;
 	}
 
 	@PostConstruct
 	public void clean() throws IOException {
-		if (cleanupOnStart) {
+		if (temporaryDirectory != null && new File(temporaryDirectory).exists()) {
 			Path directory = FileSystems.getDefault().getPath(temporaryDirectory);
 			Files.walkFileTree(directory, new CleanupFileVisitor(directory));
 		}

--- a/micro-s3/src/main/java/com/aol/micro/server/s3/S3ObjectSummaryIterator.java
+++ b/micro-s3/src/main/java/com/aol/micro/server/s3/S3ObjectSummaryIterator.java
@@ -1,0 +1,49 @@
+package com.aol.micro.server.s3;
+
+import java.util.Iterator;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ListObjectsRequest;
+import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+
+public class S3ObjectSummaryIterator implements Iterator<S3ObjectSummary> {
+
+	private final AmazonS3Client client;
+	private ListObjectsRequest req;
+	private Iterator<S3ObjectSummary> iterator;
+	private boolean empty = true;
+	public S3ObjectSummaryIterator(AmazonS3Client client, ListObjectsRequest req) {
+		this.client = client;
+		this.req = req;
+		updateIterator();
+	}
+	
+	@Override
+	public boolean hasNext() {
+		if(iterator.hasNext()) {
+			return true;
+		} else if(!empty){
+			updateIterator();
+			return iterator.hasNext();
+		} else {
+			return false;
+		}
+	}
+
+	private void updateIterator() {
+		if(iterator == null || !iterator.hasNext()) {
+			ObjectListing listing = client.listObjects(req);
+			req = req.withMarker(listing.getNextMarker());
+			empty = !listing.isTruncated();
+			iterator =  listing.getObjectSummaries().iterator();
+		}
+	}
+		
+	@Override
+	public S3ObjectSummary next() {
+		updateIterator();
+		return iterator.next();
+	}
+
+}

--- a/micro-s3/src/main/java/com/aol/micro/server/s3/S3Utils.java
+++ b/micro-s3/src/main/java/com/aol/micro/server/s3/S3Utils.java
@@ -1,29 +1,50 @@
 package com.aol.micro.server.s3;
 
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
+import org.apache.commons.io.FileUtils;
+import org.jooq.lambda.tuple.Tuple;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.DeleteObjectsRequest;
 import com.amazonaws.services.s3.model.DeleteObjectsRequest.KeyVersion;
 import com.amazonaws.services.s3.model.ListObjectsRequest;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.amazonaws.services.s3.transfer.Download;
+import com.amazonaws.services.s3.transfer.TransferManager;
 import com.aol.cyclops.control.ReactiveSeq;
+import com.aol.cyclops.util.ExceptionSoftener;
 
 @Component
 public class S3Utils {
 
 	private final AmazonS3Client client;
+	private final TransferManager transferManager;
+	private final String tmpDirectory;
 
 	@Autowired
-	public S3Utils(AmazonS3Client client) {
+	public S3Utils(AmazonS3Client client, TransferManager transferManager,
+			@Value("${s3.tmp.dir:#{null}}") String tmpDirectory) {
 		this.client = client;
+		this.transferManager = transferManager;
+		this.tmpDirectory = tmpDirectory;
 	}
 
 	public List<S3ObjectSummary> getAllSummaries(ListObjectsRequest req) {
@@ -36,14 +57,13 @@ public class S3Utils {
 			marker = listing.getNextMarker();
 			result.addAll(listing.getObjectSummaries());
 		} while (listing.isTruncated());
+
 		return result;
 	}
 
-	/*
-	 * TODO implement smarter mechanism to reduce number of queries
-	 */
 	public <T> Stream<T> getSummariesStream(ListObjectsRequest req, Function<S3ObjectSummary, T> processor) {
-		return getAllSummaries(req).stream().map(processor);
+		Iterable<S3ObjectSummary> iterable = () -> new S3ObjectSummaryIterator(client, req);
+		return StreamSupport.stream(iterable.spliterator(), false).map(processor);
 	}
 
 	public void delete(String bucketName, List<KeyVersion> objects) {
@@ -52,6 +72,25 @@ public class S3Utils {
 			req.setKeys(l.toList());
 			client.deleteObjects(req);
 		});
+	}
+
+	public InputStream getInputStream(String bucketName, String key, Supplier<File> tempFileSupplier)
+			throws AmazonServiceException, AmazonClientException, InterruptedException, IOException {
+		File file = tempFileSupplier.get();
+		try {
+			Download download = transferManager.download(bucketName, key, file);
+			download.waitForCompletion();
+			return new ByteArrayInputStream(FileUtils.readFileToByteArray(file));
+		} finally {
+			file.delete();
+		}
+	}
+
+	public InputStream getInputStream(String bucketName, String key)
+			throws AmazonServiceException, AmazonClientException, InterruptedException, IOException {
+		Supplier<File> tempFileSupplier = ExceptionSoftener.softenSupplier(() -> Files
+				.createTempFile(FileSystems.getDefault().getPath(tmpDirectory), "micro-s3", "file").toFile());
+		return getInputStream(bucketName, key, tempFileSupplier);
 	}
 
 }

--- a/micro-s3/src/main/java/com/aol/micro/server/s3/S3Utils.java
+++ b/micro-s3/src/main/java/com/aol/micro/server/s3/S3Utils.java
@@ -10,11 +10,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 import org.apache.commons.io.FileUtils;
-import org.jooq.lambda.tuple.Tuple;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -61,9 +58,8 @@ public class S3Utils {
 		return result;
 	}
 
-	public <T> Stream<T> getSummariesStream(ListObjectsRequest req, Function<S3ObjectSummary, T> processor) {
-		Iterable<S3ObjectSummary> iterable = () -> new S3ObjectSummaryIterator(client, req);
-		return StreamSupport.stream(iterable.spliterator(), false).map(processor);
+	public <T> ReactiveSeq<T> getSummariesStream(ListObjectsRequest req, Function<S3ObjectSummary, T> processor) {
+		return ReactiveSeq.fromIterator(new S3ObjectSummaryIterator(client, req)).map(processor);
 	}
 
 	public void delete(String bucketName, List<KeyVersion> objects) {

--- a/micro-s3/src/test/java/com/aol/micro/server/s3/DirectoryCleanerTest.java
+++ b/micro-s3/src/test/java/com/aol/micro/server/s3/DirectoryCleanerTest.java
@@ -14,7 +14,7 @@ public class DirectoryCleanerTest {
 		
 		
 		Path dir = Files.createTempDirectory("test");
-		DirectoryCleaner cleaner = new DirectoryCleaner(dir.toString(), true);
+		DirectoryCleaner cleaner = new DirectoryCleaner(dir.toString());
 		Path file  = Files.createTempFile(dir, "a", "b");
 		Assert.assertTrue(Files.exists(file));
 		cleaner.clean();

--- a/micro-s3/src/test/java/com/aol/micro/server/s3/DirectoryCleanerTest.java
+++ b/micro-s3/src/test/java/com/aol/micro/server/s3/DirectoryCleanerTest.java
@@ -1,0 +1,24 @@
+package com.aol.micro.server.s3;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DirectoryCleanerTest {
+
+	@Test 
+	public void clean() throws IOException {
+		
+		
+		Path dir = Files.createTempDirectory("test");
+		DirectoryCleaner cleaner = new DirectoryCleaner(dir.toString(), true);
+		Path file  = Files.createTempFile(dir, "a", "b");
+		Assert.assertTrue(Files.exists(file));
+		cleaner.clean();
+		Assert.assertFalse(Files.exists(file));
+
+	}
+}


### PR DESCRIPTION
s3.temp.dir - directory to be cleaned up (null by default).
s3.temp.cleanupOnStart - flag to control whenever directory should be cleaned up on startup (false by default)

If  s3.temp.cleanupOnStart is enabled and there are some issues with temp directory (wrong permissions), application will fail at startup.