### PR TITLE
CleanupVisitor fix

### DIFF
--- a/micro-s3/src/main/java/com/aol/micro/server/s3/CleanupFileVisitor.java
+++ b/micro-s3/src/main/java/com/aol/micro/server/s3/CleanupFileVisitor.java
@@ -17,19 +17,24 @@ public class CleanupFileVisitor extends SimpleFileVisitor<Path> {
 	
 	@Override
 	public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-		Files.delete(file);
+	    deleteNotTopDirectory(file);
 		return FileVisitResult.CONTINUE;
 	}
 
 	@Override
 	public FileVisitResult postVisitDirectory(Path dir, IOException e) throws IOException {
 		if (e == null) {
-			if(!dir.equals(tempDirectory)) {
-				Files.delete(dir);
-			}
+			deleteNotTopDirectory(dir);
 			return FileVisitResult.CONTINUE;
 		} else {
 			throw e;
 		}
 	}
+	
+	private void deleteNotTopDirectory(Path dir) throws IOException {
+	    if(!dir.equals(tempDirectory)) {
+	        Files.delete(dir);
+	    }
+	}
+	
 }


### PR DESCRIPTION
visitFile in SimpleFileVisitor treat symlinks to directories as files, so it may accidently delete "s3.temp.dir".