### PR TITLE
Changing version for tomcat to 9.0-m6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -27,5 +27,5 @@ ebayCORSVersion=1.0.1
 dbcp2Version=2.1.1
 log4jVersion=1.2.17
 s3Version=1.10.42
-tomcatVersion=9.0.0.M9
+tomcatVersion=9.0.0.M6
 commonsIOVersion=2.5


### PR DESCRIPTION
m9 is not found in repositories.