### PR TITLE
Add JsonProperty annotations to ErrorCode constructor.

### DIFF
--- a/micro-error-codes/src/main/java/com/aol/micro/server/errors/ErrorCode.java
+++ b/micro-error-codes/src/main/java/com/aol/micro/server/errors/ErrorCode.java
@@ -2,6 +2,7 @@ package com.aol.micro.server.errors;
 
 import java.text.MessageFormat;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 
 @Getter
@@ -36,7 +37,9 @@ public class ErrorCode {
                              errorId, message, Severity.CRITICAL);
     }
 
-    private ErrorCode(final int errorId, final String message, final Severity severity) {
+    private ErrorCode(@JsonProperty("errorId") final int errorId,
+                      @JsonProperty("message") final String message,
+                      @JsonProperty("severity") final Severity severity) {
 
         this.errorId = errorId;
         this.message = message;


### PR DESCRIPTION
The ErrorCode class cannot be deserialised from a JSON response currently as
it has no default constructor, and simply adding a default constructor
wouldn't work with the final fields. Add the @JsonProperty annotation to the
actual constructor so that Jackson can create instances of this.

This is needed for consumers of endpoints returning instances of HealthStatus
as HealthStatus contains an ErrorCode field.