### PR TITLE
micro server ssl support

### DIFF
--- a/micro-core/src/main/java/com/aol/micro/server/MicroserverApp.java
+++ b/micro-core/src/main/java/com/aol/micro/server/MicroserverApp.java
@@ -146,15 +146,9 @@ public class MicroserverApp {
         }
 
         ServerApplication app = applications.get(0)
-                                            .createApp(module, springContext);
-
-        if (Config.instance()
-                  .getSslProperties() != null)
-            return app.withSSLProperties(Config.instance()
-                                               .getSslProperties());
-        else
-            return app;
-    }
+                                            .createApp(module, springContext);        
+        return app;
+    }    
 
     private void join(Thread thread) {
         try {

--- a/micro-core/src/main/java/com/aol/micro/server/config/Classes.java
+++ b/micro-core/src/main/java/com/aol/micro/server/config/Classes.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import lombok.Getter;
 import nonautoscan.com.aol.micro.server.AopConfig;
+import nonautoscan.com.aol.micro.server.SSLConfig;
 import nonautoscan.com.aol.micro.server.ScheduleAndAsyncConfig;
 
 import com.aol.micro.server.module.ConfigureEnviroment;
@@ -28,7 +29,7 @@ public class Classes {
 	 * Codahale Metrics, Event tracking etc
 	 */
 	public static final  Classes CORE_CLASSES = new Classes(PropertyFileConfig.class, AopConfig.class,
-			 ScheduleAndAsyncConfig.class,  ConfigureEnviroment.class, AccessLogConfig.class);
+			 ScheduleAndAsyncConfig.class,  ConfigureEnviroment.class, AccessLogConfig.class, SSLConfig.class);
 	
 	
 	@Getter

--- a/micro-core/src/main/java/com/aol/micro/server/config/Config.java
+++ b/micro-core/src/main/java/com/aol/micro/server/config/Config.java
@@ -36,7 +36,6 @@ public class Config {
     private final String instancePropertiesName;
     private final String serviceTypePropertiesName;
     private final PMap<String, List<String>> dataSources;
-    private final SSLProperties sslProperties;
     private final boolean allowCircularReferences;
     private final String[] basePackages;
 
@@ -48,7 +47,6 @@ public class Config {
         propertiesName = "application.properties";
         instancePropertiesName = "instance.properties";
         serviceTypePropertiesName = "service-type.properties";
-        sslProperties = null;
         allowCircularReferences = false;
         basePackages = new String[0];
 

--- a/micro-core/src/main/java/com/aol/micro/server/config/SSLProperties.java
+++ b/micro-core/src/main/java/com/aol/micro/server/config/SSLProperties.java
@@ -44,4 +44,10 @@ public class SSLProperties {
 	public AnyM<String> getProtocol() {
 		return AnyM.ofNullable(protocol);
 	}
+	public AnyM<String> getTrustStoreFile() {
+		return AnyM.ofNullable(trustStoreFile);
+	}
+	public AnyM<String> getTrustStorePass() {
+		return AnyM.ofNullable(trustStorePass);
+	}
 }

--- a/micro-core/src/main/java/com/aol/micro/server/servers/ServerApplication.java
+++ b/micro-core/src/main/java/com/aol/micro/server/servers/ServerApplication.java
@@ -6,8 +6,6 @@ import com.aol.micro.server.config.SSLProperties;
 import com.aol.micro.server.servers.model.ServerData;
 
 public interface ServerApplication {
-
 	void run(CompletableFuture start, JaxRsServletConfigurer jaxRsConfigurer, CompletableFuture end);
-	ServerData getServerData();
-	ServerApplication withSSLProperties(SSLProperties sslProperties);
+	ServerData getServerData();	
 }

--- a/micro-core/src/main/java/nonautoscan/com/aol/micro/server/SSLConfig.java
+++ b/micro-core/src/main/java/nonautoscan/com/aol/micro/server/SSLConfig.java
@@ -1,0 +1,54 @@
+package nonautoscan.com.aol.micro.server;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Properties;
+
+import org.springframework.beans.factory.config.PropertiesFactoryBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+
+import com.aol.micro.server.config.SSLProperties;
+
+@Configuration
+public class SSLConfig {
+
+	private static String keyStoreFile = "keyStoreFile";
+	private static String keyStorePass = "keyStorePass";
+	private static String trustStoreFile = "trustStoreFile";
+	private static String trustStorePass = "trustStorePass";
+	private static String keyStoreType = "keyStoreType";
+	private static String keyStoreProvider = "keyStoreProvider";
+	private static String trustStoreType = "trustStoreType";
+	private static String trustStoreProvider = "trustStoreProvider";
+	private static String clientAuth = "clientAuth";
+	private static String ciphers = "ciphers";
+	private static String protocol = "protocol";
+
+	@Bean
+	public static SSLProperties sslProperties() throws IOException {
+		PropertiesFactoryBean factory = new PropertiesFactoryBean();
+		URL url = SSLConfig.class.getClassLoader().getResource("ssl.properties");
+		if (url != null) {
+			Resource reource = new UrlResource(url);
+			factory.setLocation(reource);
+			factory.afterPropertiesSet();
+			Properties properties = factory.getObject();
+			return SSLProperties.builder()
+					.keyStoreFile(properties.getProperty(keyStoreFile))
+					.keyStorePass(properties.getProperty(keyStorePass))
+					.trustStoreFile(properties.getProperty(trustStoreFile))
+					.trustStorePass(properties.getProperty(trustStorePass))
+					.keyStoreType(properties.getProperty(keyStoreType))
+					.keyStoreProvider(properties.getProperty(keyStoreProvider))
+					.trustStoreType(properties.getProperty(trustStoreType))
+					.trustStoreProvider(properties.getProperty(trustStoreProvider))
+					.clientAuth(properties.getProperty(clientAuth))
+					.ciphers(properties.getProperty(ciphers))
+					.protocol(properties.getProperty(protocol)).build();
+		}
+		return null;
+	}
+}

--- a/micro-grizzly/src/main/java/com/aol/micro/server/servers/grizzly/SSLConfigurationBuilder.java
+++ b/micro-grizzly/src/main/java/com/aol/micro/server/servers/grizzly/SSLConfigurationBuilder.java
@@ -14,8 +14,13 @@ public class SSLConfigurationBuilder {
 
         sslContext.setKeyStoreFile(sslProperties.getKeyStoreFile()); // contains server keypair
         sslContext.setKeyStorePass(sslProperties.getKeyStorePass());
-        sslContext.setTrustStoreFile(sslProperties.getTrustStoreFile()); // contains client certificate
-        sslContext.setTrustStorePass(sslProperties.getTrustStorePass());
+        
+        /**
+         * trustStore stores public key or certificates from CA (Certificate Authorities) 
+         * which is used to trust remote party or SSL connection. So should be optional
+         */
+        sslProperties.getTrustStoreFile().peek(file->sslContext.setTrustStoreFile(file)); // contains client certificate
+        sslProperties.getTrustStorePass().peek(pass->sslContext.setTrustStorePass(pass));
         
         
         

--- a/micro-tomcat/src/main/java/com/aol/micro/server/servers/tomcat/SSLConfigurationBuilder.java
+++ b/micro-tomcat/src/main/java/com/aol/micro/server/servers/tomcat/SSLConfigurationBuilder.java
@@ -16,8 +16,9 @@ public class SSLConfigurationBuilder {
         sslProperties.getKeyStoreType().peek(type->protocol.setKeystoreType(type));
         sslProperties.getKeyStoreProvider().peek(provider->protocol.setKeystoreProvider(provider));
 		
-        protocol.setTruststoreFile(sslProperties.getTrustStoreFile()); // contains client certificate
-        protocol.setTruststorePass(sslProperties.getTrustStorePass());
+        sslProperties.getTrustStoreFile().peek(file->protocol.setTruststoreFile(file)); // contains client certificate
+        sslProperties.getTrustStorePass().peek(pass->protocol.setTruststorePass(pass));
+        
         sslProperties.getTrustStoreType().peek(type->protocol.setTruststoreType(type));
         sslProperties.getTrustStoreProvider().peek(provider->protocol.setTruststoreProvider(provider));
 		sslProperties.getClientAuth().peek(auth->protocol.setClientAuth(auth));

--- a/micro-tomcat/src/main/java/com/aol/micro/server/servers/tomcat/TomcatApplication.java
+++ b/micro-tomcat/src/main/java/com/aol/micro/server/servers/tomcat/TomcatApplication.java
@@ -49,16 +49,13 @@ public class TomcatApplication implements ServerApplication {
 	private final PStack<ServletData> servletData;
 	private final PStack<ServletContextListener> servletContextListenerData;
 	private final PStack<ServletRequestListener> servletRequestListenerData;
-	@Wither
-	private final SSLProperties SSLProperties;
-
+	
 	public TomcatApplication(AllData serverData) {
 		this.serverData = serverData.getServerData();
 		this.filterData = serverData.getFilterDataList();
 		this.servletData = serverData.getServletDataList();
 		this.servletContextListenerData = serverData.getServletContextListeners();
-		this.servletRequestListenerData = serverData.getServletRequestListeners();
-		this.SSLProperties = null;
+		this.servletRequestListenerData = serverData.getServletRequestListeners();	
 	}
 
 	public void run(CompletableFuture start,  JaxRsServletConfigurer jaxRsConfigurer, CompletableFuture end) {
@@ -74,23 +71,19 @@ public class TomcatApplication implements ServerApplication {
 	
 		serverData.getModule().getServerConfigManager().accept(new WebServerProvider(tomcat));
 		
-		if(SSLProperties!=null){
-			addSSL(tomcat.getConnector(),SSLProperties);	
-		}
+		addSSL(tomcat.getConnector());	
 
-		startServer( tomcat, start, end);
+		startServer(tomcat, start, end);
 	}
 
-	private void addSSL(Connector connector,SSLProperties sslProperties) {
+	private void addSSL(Connector connector) {
+		SSLProperties sslProperties = serverData.getRootContext().getBean(SSLProperties.class);
 		ProtocolHandler handler = connector.getProtocolHandler();
-		if(handler instanceof AbstractHttp11JsseProtocol){
+		if(sslProperties!= null && handler instanceof AbstractHttp11JsseProtocol){
 			new SSLConfigurationBuilder().build((AbstractHttp11JsseProtocol)handler,sslProperties);
 			connector.setScheme("https");
-			connector.setSecure(true);
-			
-		}
-		
-		
+			connector.setSecure(true);		
+		}		
 	}
 
 	private void startServer( Tomcat httpServer, CompletableFuture start, CompletableFuture end) {


### PR DESCRIPTION
Hi Guys,

Fixed the SSL support for micro-server. TrustStore stores public key or certificates from CA (Certificate Authorities)  which is used to trust remote party or SSL connection. So trustStoreFile and trustStorePass should be optional. If a file named ssl.properties presents on classpath, ssl will be enabled.

Thanks,
Ke