### PR TITLE
Fix S3ManifestComparator being unable to load version 1 files.

### DIFF
--- a/micro-s3/src/main/java/com/aol/micro/server/s3/manifest/comparator/S3ManifestComparator.java
+++ b/micro-s3/src/main/java/com/aol/micro/server/s3/manifest/comparator/S3ManifestComparator.java
@@ -193,6 +193,13 @@ public class S3ManifestComparator<T> implements ManifestComparator<T> {
     }
 
     /**
+     * @return true - if current data is stale and needs refreshed
+     */
+    private boolean needsData() {
+        return this.data.isSecondary();
+    }
+
+    /**
      * Load data from remote store if stale
      */
     @Override
@@ -201,7 +208,7 @@ public class S3ManifestComparator<T> implements ManifestComparator<T> {
         long oldModified = modified;
         String oldKey = versionedKey;
         try {
-            if (isOutOfDate()) {
+            if (isOutOfDate() || needsData()) {
                 String newVersionedKey = reader.getAsString(key)
                                                .get();
                 val loaded = nonAtomicload(newVersionedKey);

--- a/micro-s3/src/test/java/com/aol/micro/server/s3/manifest/comparator/S3ManifestComparatorTest.java
+++ b/micro-s3/src/test/java/com/aol/micro/server/s3/manifest/comparator/S3ManifestComparatorTest.java
@@ -1,0 +1,81 @@
+package com.aol.micro.server.s3.manifest.comparator;
+
+import com.aol.cyclops.control.Try;
+import com.aol.micro.server.manifest.Data;
+import com.aol.micro.server.manifest.VersionedKey;
+import com.aol.micro.server.s3.data.S3Deleter;
+import com.aol.micro.server.s3.data.S3ObjectWriter;
+import com.aol.micro.server.s3.data.S3Reader;
+import com.aol.micro.server.s3.data.S3StringWriter;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Date;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class S3ManifestComparatorTest {
+
+    @Mock
+    private S3Reader reader;
+    @Mock
+    private S3StringWriter stringWriter;
+    @Mock
+    private S3Deleter deleter;
+    @Mock
+    private S3ObjectWriter objectWriter;
+
+    private String versionKey;
+    private Date lastModTime;
+    private Data<String> expectedData;
+
+    @Before
+    public void setup() {
+        lastModTime = new Date();
+        setupExpectedData(lastModTime, "foobar", "data", 1L);
+    }
+
+    private void setupExpectedData(Date lastModTime, String key, String data, long version) {
+        expectedData = new Data<>(data, lastModTime, versionKey);
+        versionKey = new VersionedKey(key, version).toJson();
+        when(reader.getAsString(key)).thenReturn(Try.of(versionKey));
+        when(reader.getAsObject(versionKey)).thenReturn(Try.of(expectedData));
+        when(reader.getLastModified(versionKey)).thenReturn(lastModTime);
+    }
+
+    @Test
+    public void loadInitial() throws Exception {
+        S3ManifestComparator<String> comparator = new S3ManifestComparator<>("foobar", reader, objectWriter, deleter, stringWriter);
+        comparator.load();
+        assertEquals("data", comparator.getData());
+        verify(reader, times(1)).getAsObject(versionKey);
+    }
+
+    @Test
+    public void loadUnchanged() throws Exception {
+        S3ManifestComparator<String> comparator = new S3ManifestComparator<>("foobar", reader, objectWriter, deleter, stringWriter);
+        comparator.load();
+        assertEquals("data", comparator.getData());
+        comparator.load();
+        assertEquals("data", comparator.getData());
+        verify(reader, times(1)).getAsObject(versionKey);
+    }
+
+    @Test
+    public void loadUpdated() throws Exception {
+        S3ManifestComparator<String> comparator = new S3ManifestComparator<>("foobar", reader, objectWriter, deleter, stringWriter);
+        comparator.load();
+        assertEquals("data", comparator.getData());
+        setupExpectedData(new Date(), "foobar", "data2", 2L);
+        comparator.load();
+        assertEquals("data2", comparator.getData());
+    }
+
+}


### PR DESCRIPTION
Check if there's data loaded as well as that the known version is the
current version before deciding not to load the data from the manifest
comparator. Also add some tests for S3ManifestComparator.

Fixes #322.