### PR TITLE
Host for metrics-datadog from host.address

### DIFF
--- a/micro-metrics-datadog/src/test/java/com/aol/micro/server/datadog/metrics/DatadogMetricsConfigurerTest.java
+++ b/micro-metrics-datadog/src/test/java/com/aol/micro/server/datadog/metrics/DatadogMetricsConfigurerTest.java
@@ -20,7 +20,7 @@ public class DatadogMetricsConfigurerTest {
     public void expansionsDefault() {
         String expStr = null;
         DatadogMetricsConfigurer c = new DatadogMetricsConfigurer(
-                                                                  apiKey, tags, period, timeUnit, expStr);
+                                                                  apiKey, tags, period, timeUnit, expStr, null);
         assertThat(c.getExpansions(), equalTo(DatadogReporter.Expansion.ALL));
     }
 
@@ -28,7 +28,7 @@ public class DatadogMetricsConfigurerTest {
     public void expansionsSingle() {
         String expStr = DatadogReporter.Expansion.MEDIAN.name();
         DatadogMetricsConfigurer c = new DatadogMetricsConfigurer(
-                                                                  apiKey, tags, period, timeUnit, expStr);
+                                                                  apiKey, tags, period, timeUnit, expStr, null);
         assertThat(c.getExpansions(), equalTo(EnumSet.of(DatadogReporter.Expansion.MEDIAN)));
     }
 
@@ -36,7 +36,7 @@ public class DatadogMetricsConfigurerTest {
     public void expansionsTwo() {
         String expStr = DatadogReporter.Expansion.MEDIAN.name() + "," + DatadogReporter.Expansion.RATE_15_MINUTE.name();
         DatadogMetricsConfigurer c = new DatadogMetricsConfigurer(
-                                                                  apiKey, tags, period, timeUnit, expStr);
+                                                                  apiKey, tags, period, timeUnit, expStr, null);
         assertThat(c.getExpansions(),
                    equalTo(EnumSet.of(DatadogReporter.Expansion.MEDIAN, DatadogReporter.Expansion.RATE_15_MINUTE)));
     }
@@ -46,7 +46,7 @@ public class DatadogMetricsConfigurerTest {
         String expStr = DatadogReporter.Expansion.MEDIAN.name() + " , "
                 + DatadogReporter.Expansion.RATE_15_MINUTE.name();
         DatadogMetricsConfigurer c = new DatadogMetricsConfigurer(
-                                                                  apiKey, tags, period, timeUnit, expStr);
+                                                                  apiKey, tags, period, timeUnit, expStr, null);
         assertThat(c.getExpansions(),
                    equalTo(EnumSet.of(DatadogReporter.Expansion.MEDIAN, DatadogReporter.Expansion.RATE_15_MINUTE)));
     }


### PR DESCRIPTION
Currently micro-metrics-datadog doesn't support host field for metrics. Datadog doesn't allow setting host via host tag. This PR should fix it.