### PR TITLE
Curly braces was added to host.address injection

### DIFF
--- a/micro-metrics-datadog/src/main/java/com/aol/micro/server/datadog/metrics/DatadogMetricsConfigurer.java
+++ b/micro-metrics-datadog/src/main/java/com/aol/micro/server/datadog/metrics/DatadogMetricsConfigurer.java
@@ -40,7 +40,7 @@ public class DatadogMetricsConfigurer extends MetricsConfigurerAdapter {
             @Value("${datadog.tags:{\"stage:dev\"}}") String tags, @Value("${datadog.report.period:1}") int period,
             @Value("${datadog.report.timeunit:SECONDS}") TimeUnit timeUnit,
             @Value("${datadog.report.expansions:#{null}}") String expStr,
-	    @Value("${host.address:#{null}") String host){
+	    @Value("${host.address:#{null}}") String host){
         this.apiKey = apiKey;
         this.tags = Arrays.asList(Optional.ofNullable(tags)
                                           .orElse("")


### PR DESCRIPTION
We were using wrong value for hostname because of that.