### PR TITLE
InstantGauge to use with datadog

### DIFF
--- a/micro-metrics/src/main/java/com/aol/micro/server/spring/metrics/InstantGauge.java
+++ b/micro-metrics/src/main/java/com/aol/micro/server/spring/metrics/InstantGauge.java
@@ -1,0 +1,24 @@
+package com.aol.micro.server.spring.metrics;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.codahale.metrics.Gauge;
+
+
+public class InstantGauge implements Gauge<Long> {
+
+	private final AtomicLong counter = new AtomicLong(0l);
+
+	@Override
+	public Long getValue() {
+		return counter.getAndSet(0l);
+		}
+
+	public void increment() {
+		counter.incrementAndGet();
+	}
+
+	public void increase(long value) {
+		counter.addAndGet(value);
+	}
+}

--- a/micro-metrics/src/test/java/com/aol/micro/server/spring/metrics/InstantGaugeTest.java
+++ b/micro-metrics/src/test/java/com/aol/micro/server/spring/metrics/InstantGaugeTest.java
@@ -1,0 +1,19 @@
+package com.aol.micro.server.spring.metrics;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class InstantGaugeTest {
+
+	@Test
+	public void instantGauge() {
+		InstantGauge gauge = new InstantGauge();
+		gauge.increment();
+		gauge.increase(3);
+
+		assertEquals(4l ,gauge.getValue().longValue());
+		assertEquals(0l ,gauge.getValue().longValue());
+
+	}
+
+}


### PR DESCRIPTION
Counters from dropwizard metrics provide accumulated value, so if we restart an application, it starts from zero. It doesn't look good on graphs. InstantGauge does provide "instant" value. It will report difference in value between two measurements. Results of this gauge can be aggregated on a monitoring side, contrary to default gauge implementation provided by dropwizard metrics.