### PR TITLE
Application registry filter

### DIFF
--- a/micro-application-register/src/main/java/com/aol/micro/server/application/registry/Finder.java
+++ b/micro-application-register/src/main/java/com/aol/micro/server/application/registry/Finder.java
@@ -3,6 +3,8 @@ package com.aol.micro.server.application.registry;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
@@ -24,8 +26,13 @@ public class Finder {
 		this.config = config;
 	}
 
-	public List<RegisterEntry> find() {
-		return findDir(new File(config.getOutputDir()));
+	public List<RegisterEntry> find(final Optional<RegisterEntry> re) {
+
+		List<RegisterEntry> entries = findDir(new File(config.getOutputDir()));
+		if (re.isPresent()) {
+			entries = entries.stream().filter( e -> e.matches(re.get())).collect(Collectors.toList());
+		}
+		return entries;
 	}
 
 	private List<RegisterEntry> findDir(File dir) {

--- a/micro-application-register/src/main/java/com/aol/micro/server/application/registry/RegisterEntry.java
+++ b/micro-application-register/src/main/java/com/aol/micro/server/application/registry/RegisterEntry.java
@@ -1,11 +1,9 @@
 package com.aol.micro.server.application.registry;
 
 import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
+import javax.ws.rs.QueryParam;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
@@ -26,45 +24,40 @@ import lombok.experimental.Wither;
 @Builder
 public class RegisterEntry {
 
-    private static SimpleDateFormat f = new SimpleDateFormat(
-                                                             "EEE, d MMM yyyy HH:mm:ss Z");
+    private static SimpleDateFormat f = new SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss Z");
     @Wither
-    int port;
+    private final int port;
     @Wither
-    String hostname;
+    private final String hostname;
     @Wither
-    String module;
+    private final String module;
     @Wither
-    String context;
-    Date time;
+    private final String context;
+    private final Date time;
     @Wither
-    String uuid;
+    private final String uuid;
     @Wither
-    String target;
-    String formattedDate;
-    Map<String, String> manifest = ManifestLoader.instance.getManifest();
+    private final String target;
+    private final String formattedDate;
+    private final Map<String, String> manifest = ManifestLoader.instance.getManifest();
     @Wither
-    Health health;
+    private final Health health;
     @Wither
-    List<Map<String, Map<String, String>>> stats;
+    private final List<Map<String, Map<String, String>>> stats;
     @Wither
-    int externalPort;
+    private final int externalPort;
 
     public RegisterEntry() {
-        this(
-             -1, null, null, null, null, null, null, -1);
+        this(-1, null, null, null, null, null, null, -1);
     }
 
     public RegisterEntry(int port, String hostname, String module, String context, Date time, String uuid,
-            String target, int externalPort) {
-        this(
-             port, hostname, module, context, time, UUID.randomUUID()
-                                                        .toString(),
-             target, null, Health.OK, null, externalPort);
+                         String target, int externalPort) {
+        this(port, hostname, module, context, time, UUID.randomUUID().toString(), target, Health.OK, null, externalPort);
     }
 
     private RegisterEntry(int port, String hostname, String module, String context, Date time, String uuid,
-            String target, String ignoreDate, Health health, List<Map<String, Map<String, String>>> stats,
+            String target, Health health, List<Map<String, Map<String, String>>> stats,
             int externalPort) {
         this.port = port;
         this.hostname = hostname;
@@ -85,11 +78,22 @@ public class RegisterEntry {
     }
 
     public RegisterEntry(int port, String hostname, String module, String context, Date time, String target,
-            int externalPort) {
-        this(
-             port, hostname, module, context, time, UUID.randomUUID()
-                                                        .toString(),
-             target, externalPort);
+                         int externalPort) {
+        this(port, hostname, module, context, time, UUID.randomUUID().toString(), target, externalPort);
+    }
+
+    public boolean matches(RegisterEntry re) {
+        return  (re.port == -1 || re.port == port) &&
+                (Objects.nonNull(re.hostname) || Objects.nonNull(hostname) && hostname.startsWith(re.hostname)) &&
+                (Objects.nonNull(re.module) || Objects.nonNull(module) && module.startsWith(re.module)) &&
+                (Objects.nonNull(re.context) || Objects.nonNull(context) && context.startsWith(re.context)) &&
+                (Objects.nonNull(re.health) || re.health.equals(health)) &&
+                (re.externalPort == -1 || re.externalPort != externalPort) &&
+                (Objects.nonNull(re.manifest) || (
+                        (!re.manifest.containsKey("Implementation-revision")) || re.manifest.get("Implementation-revision").equals(manifest.get("Implementation-revision")) &&
+                        (!re.manifest.containsKey("Implementation-Timestamp")) || re.manifest.get("Implementation-Timestamp").equals(manifest.get("Implementation-Timestamp")) &&
+                        (!re.manifest.containsKey("Implementation-Version")) || re.manifest.get("Implementation-Version").equals(manifest.get("Implementation-Version"))
+                ));
     }
 
 }

--- a/micro-application-register/src/main/java/com/aol/micro/server/application/registry/RegisterEntry.java
+++ b/micro-application-register/src/main/java/com/aol/micro/server/application/registry/RegisterEntry.java
@@ -53,11 +53,16 @@ public class RegisterEntry {
 
     public RegisterEntry(int port, String hostname, String module, String context, Date time, String uuid,
                          String target, int externalPort) {
-        this(port, hostname, module, context, time, UUID.randomUUID().toString(), target, Health.OK, null, externalPort);
+        this(port, hostname, module, context, time, UUID.randomUUID().toString(), target, null, Health.OK, null, externalPort);
+    }
+
+    public RegisterEntry(int port, String hostname, String module, String context, Date time, String target,
+                         int externalPort) {
+        this(port, hostname, module, context, time, UUID.randomUUID().toString(), target, externalPort);
     }
 
     private RegisterEntry(int port, String hostname, String module, String context, Date time, String uuid,
-            String target, Health health, List<Map<String, Map<String, String>>> stats,
+            String target, String ignoreDate, Health health, List<Map<String, Map<String, String>>> stats,
             int externalPort) {
         this.port = port;
         this.hostname = hostname;
@@ -77,19 +82,14 @@ public class RegisterEntry {
 
     }
 
-    public RegisterEntry(int port, String hostname, String module, String context, Date time, String target,
-                         int externalPort) {
-        this(port, hostname, module, context, time, UUID.randomUUID().toString(), target, externalPort);
-    }
-
     public boolean matches(RegisterEntry re) {
         return  (re.port == -1 || re.port == port) &&
-                (Objects.nonNull(re.hostname) || Objects.nonNull(hostname) && hostname.startsWith(re.hostname)) &&
-                (Objects.nonNull(re.module) || Objects.nonNull(module) && module.startsWith(re.module)) &&
-                (Objects.nonNull(re.context) || Objects.nonNull(context) && context.startsWith(re.context)) &&
-                (Objects.nonNull(re.health) || re.health.equals(health)) &&
+                (Objects.isNull(re.hostname) || Objects.nonNull(hostname) && hostname.startsWith(re.hostname)) &&
+                (Objects.isNull(re.module) || Objects.nonNull(module) && module.startsWith(re.module)) &&
+                (Objects.isNull(re.context) || Objects.nonNull(context) && context.startsWith(re.context)) &&
+                (Objects.isNull(re.health) || re.health.equals(health)) &&
                 (re.externalPort == -1 || re.externalPort != externalPort) &&
-                (Objects.nonNull(re.manifest) || (
+                (Objects.isNull(re.manifest) || (
                         (!re.manifest.containsKey("Implementation-revision")) || re.manifest.get("Implementation-revision").equals(manifest.get("Implementation-revision")) &&
                         (!re.manifest.containsKey("Implementation-Timestamp")) || re.manifest.get("Implementation-Timestamp").equals(manifest.get("Implementation-Timestamp")) &&
                         (!re.manifest.containsKey("Implementation-Version")) || re.manifest.get("Implementation-Version").equals(manifest.get("Implementation-Version"))

--- a/micro-application-register/src/main/java/com/aol/micro/server/application/registry/ServiceRegistryResource.java
+++ b/micro-application-register/src/main/java/com/aol/micro/server/application/registry/ServiceRegistryResource.java
@@ -1,14 +1,13 @@
 package com.aol.micro.server.application.registry;
 
 import java.util.Arrays;
+import java.util.Optional;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriInfo;
 
 import cyclops.stream.ReactiveSeq;
 import org.slf4j.Logger;
@@ -42,18 +41,17 @@ public class ServiceRegistryResource{
 	@GET
 	@Path("/list")
 	@Produces("application/json")
-	public void list(@Suspended AsyncResponse response) {
+	public void list(@Context UriInfo uriInfo, @Suspended AsyncResponse response) {
 		ReactiveSeq.of(this).foldFuture(WorkerThreads.ioExecutor.get(),
 				s->s.forEach(Long.MAX_VALUE,next -> {
 			try{
 				cleaner.clean();
-				response.resume(finder.find());
+				response.resume(finder.find(UriInfoParser.toRegisterEntry(uriInfo)));
 			}catch(Exception e){
 				logger.error(e.getMessage(),e);
 				response.resume(Arrays.asList("failed due to error"));
 			}
 		}));
-		
 	}
 
 	@POST

--- a/micro-application-register/src/main/java/com/aol/micro/server/application/registry/ServiceRegistryResource.java
+++ b/micro-application-register/src/main/java/com/aol/micro/server/application/registry/ServiceRegistryResource.java
@@ -7,6 +7,8 @@ import javax.ws.rs.*;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
 import cyclops.stream.ReactiveSeq;
@@ -18,6 +20,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import com.aol.micro.server.WorkerThreads;
 import com.aol.micro.server.auto.discovery.Rest;
 import com.aol.micro.server.utility.HashMapBuilder;
+
+import static javax.ws.rs.core.Response.Status.*;
 
 
 @Rest
@@ -49,7 +53,7 @@ public class ServiceRegistryResource{
 				response.resume(finder.find(UriInfoParser.toRegisterEntry(uriInfo)));
 			}catch(Exception e){
 				logger.error(e.getMessage(),e);
-				response.resume(Arrays.asList("failed due to error"));
+				response.resume(Arrays.asList("Bad Request: " + e.getMessage()));
 			}
 		}));
 	}

--- a/micro-application-register/src/main/java/com/aol/micro/server/application/registry/UriInfoParser.java
+++ b/micro-application-register/src/main/java/com/aol/micro/server/application/registry/UriInfoParser.java
@@ -1,0 +1,17 @@
+package com.aol.micro.server.application.registry;
+
+import javax.ws.rs.core.UriInfo;
+import java.util.Optional;
+
+public class UriInfoParser {
+
+    public static Optional<RegisterEntry> toRegisterEntry(UriInfo uriInfo) {
+        if (uriInfo.getQueryParameters().isEmpty()) {
+            return Optional.empty();
+        } else {
+            RegisterEntry re = new RegisterEntry();
+            // TODO: add the population logic
+            return Optional.of(re);
+        }
+    }
+}

--- a/micro-application-register/src/main/java/com/aol/micro/server/application/registry/UriInfoParser.java
+++ b/micro-application-register/src/main/java/com/aol/micro/server/application/registry/UriInfoParser.java
@@ -1,6 +1,12 @@
 package com.aol.micro.server.application.registry;
 
+import cyclops.stream.ReactiveSeq;
+
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 public class UriInfoParser {
@@ -9,9 +15,49 @@ public class UriInfoParser {
         if (uriInfo.getQueryParameters().isEmpty()) {
             return Optional.empty();
         } else {
-            RegisterEntry re = new RegisterEntry();
-            // TODO: add the population logic
+            MultivaluedMap<String, String> parameters = uriInfo.getQueryParameters();
+            RegisterEntry re = RegisterEntry.builder()
+                    .context(parameters.getFirst("context"))
+                    .hostname(parameters.getFirst("hostname"))
+                    .port(toInt(parameters.getFirst("port")))
+                    .target(parameters.getFirst("target"))
+                    .externalPort(toInt(parameters.getFirst("externalPort")))
+                    .module(parameters.getFirst("module"))
+                    .health(toHealth(parameters.getFirst("health")))
+                    .build();
+
+            Map<String, String> manifest = ReactiveSeq.fromIterable(parameters.entrySet())
+                    .filter(e -> e.getKey().startsWith("manifest."))
+                    .toMap(e -> e.getKey().replace("manifest.", ""), e -> parameters.getFirst(e.getKey()));
+
+            re.getManifest().clear();
+            re.getManifest().putAll(manifest);
+
             return Optional.of(re);
         }
     }
+
+    private static Health toHealth(String health) {
+        if (Objects.nonNull(health)) {
+            try {
+                return Health.valueOf(health);
+            } catch (Exception e) {
+                throw new IllegalArgumentException("'" + health + "' is not valid, valid values are " +
+                        Arrays.asList(Health.values()));
+            }
+        }
+        return null;
+    }
+
+    private static int toInt(String port) {
+        if (Objects.isNull(port))
+            return -1;
+
+        try {
+            return Integer.valueOf(port);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("'" + port + "' is not a valid number.");
+        }
+    }
+
 }

--- a/micro-application-register/src/test/java/app/registry/com/aol/micro/server/RegistryAppRunner.java
+++ b/micro-application-register/src/test/java/app/registry/com/aol/micro/server/RegistryAppRunner.java
@@ -95,4 +95,9 @@ public class RegistryAppRunner {
         }
     }
 
+    public static void main(String[] args) {
+        RegistryAppRunner appRunner = new RegistryAppRunner();
+        appRunner.startServer();
+    }
+
 }

--- a/micro-application-register/src/test/java/app/registry/com/aol/micro/server/RegistryAppRunner.java
+++ b/micro-application-register/src/test/java/app/registry/com/aol/micro/server/RegistryAppRunner.java
@@ -1,5 +1,6 @@
 package app.registry.com.aol.micro.server;
 
+import static java.util.stream.Collectors.joining;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -7,8 +8,12 @@ import static org.junit.Assert.assertThat;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Stream;
 
+import com.aol.micro.server.rest.client.RestClient;
+import com.fasterxml.jackson.core.type.TypeReference;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -25,17 +30,15 @@ import com.aol.micro.server.testing.RestAgent;
 public class RegistryAppRunner {
 
     RestAgent rest = new RestAgent();
-    private final AsyncRestClient restAsync = new AsyncRestClient(
-                                                                  100, 2000);
+    private final AsyncRestClient restAsync = new AsyncRestClient(100, 2000);
     MicroserverApp server;
+
+    String baseUrl = "http://localhost:8080/registry-app/service-registry";
 
     @Before
     public void startServer() {
-
-        server = new MicroserverApp(
-                                    () -> "registry-app");
+        server = new MicroserverApp(() -> "registry-app");
         server.start();
-
     }
 
     @After
@@ -46,58 +49,115 @@ public class RegistryAppRunner {
     @Test
     public void runAppAndBasicTest() throws InterruptedException, ExecutionException {
 
-        SimpleDateFormat f = new SimpleDateFormat(
-                                                  "EEE");
+        SimpleDateFormat f = new SimpleDateFormat("EEE");
         String date = f.format(new Date());
         Thread.sleep(1000);
 
-        assertThat(rest.post("http://localhost:8080/registry-app/service-registry/schedule"),
-                   is("{\"status\":\"success\"}"));
+        assertThat(rest.post(baseUrl + "/schedule"), is("{\"status\":\"success\"}"));
         Thread.sleep(1000);
-        assertThat(rest.getJson("http://localhost:8080/registry-app/service-registry/list"),
-                   containsString("[{\"port\":8080,"));
-        assertThat(rest.getJson("http://localhost:8080/registry-app/service-registry/list"),
-                   containsString("externalPort\":8080"));
 
-        sendPing(new RegisterEntry(
-                                   8081, "use-ip", "hello", "world", new Date(), "my-target", 8082));
+        String listResponse = rest.getJson(baseUrl + "/list");
+
+        assertThat(listResponse, containsString("[{\"port\":8080,"));
+        assertThat(listResponse, containsString("externalPort\":8080"));
+
+        sendPing("1", 8081, "use-ip", "hello", "world", "my-target", 8082);
         Thread.sleep(1000);
-        System.out.println(rest.getJson("http://localhost:8080/registry-app/service-registry/list"));
-        assertThat(rest.getJson("http://localhost:8080/registry-app/service-registry/list"),
-                   containsString("{\"port\":8081,"));
 
-        assertThat(rest.getJson("http://localhost:8080/registry-app/service-registry/list"),
-                   containsString("\"target\":\"my-target\""));
-        assertThat(rest.getJson("http://localhost:8080/registry-app/service-registry/list"),
-                   containsString("\"target\":\"configured-target\""));
-        assertThat(rest.getJson("http://localhost:8080/registry-app/service-registry/list"),
-                   not(containsString("\"hostname\":\"test-host\"")));
-        assertThat(rest.getJson("http://localhost:8080/registry-app/service-registry/list"),
-                   containsString("\"formattedDate\""));
-        assertThat(rest.getJson("http://localhost:8080/registry-app/service-registry/list"),
-                   containsString("\"manifest\""));
-        assertThat(rest.getJson("http://localhost:8080/registry-app/service-registry/list"),
-                   containsString("Manifest-Version"));
+        listResponse = rest.getJson(baseUrl + "/list");;
 
-        assertThat(rest.getJson("http://localhost:8080/registry-app/service-registry/list"), containsString(date));
+        assertThat(listResponse, containsString("{\"port\":8081,"));
+        assertThat(listResponse, containsString("\"target\":\"my-target\""));
+        assertThat(listResponse, containsString("\"target\":\"configured-target\""));
+        assertThat(listResponse, not(containsString("\"hostname\":\"test-host\"")));
+        assertThat(listResponse, containsString("\"formattedDate\""));
+        assertThat(listResponse, containsString("\"manifest\""));
+        assertThat(listResponse, containsString("Manifest-Version"));
+        assertThat(listResponse, containsString(date));
 
     }
 
-    private void sendPing(RegisterEntry entry) {
+    @Test
+    public void filterTest() throws Exception {
+        Thread.sleep(1000);
 
+        List<RegisterEntry> entries = list();
+        assertThat(entries.size(), is(1));
+
+        sendPing("121", 8080, "host1", "module1", "context1", "target1", 9080);
+        sendPing("122", 8080, "host2", "module1", "context1", "target1", 9080);
+        sendPing("131", 6080, "host3", "module2", "context2", "target2", 7080);
+        sendPing("132", 6080, "host4", "module2", "context2", "target2", 7080);
+
+        entries = list();
+        assertThat(entries.size(), is(5));
+
+        entries = list("port=8080");
+        assertThat(entries.size(), is(3));
+
+        entries = list("port=8080", "externalPort=9080");
+        System.out.println(entries);
+        assertThat(entries.size(), is(2));
+
+        entries = list("port=8080", "externalPort=9080", "module=module", "context=context1");
+        assertThat(entries.size(), is(2));
+
+        entries = list("port=8080", "externalPort=9080", "module=module", "context=context1", "hostname=host1");
+        assertThat(entries.size(), is(1));
+
+        entries = list("port=8080", "externalPort=9080", "module=module1", "context=context2");
+        assertThat(entries.size(), is(0));
+
+        entries = list("manifest.Implementation-Version=version");
+        assertThat(entries.size(), is(4));
+
+        entries = list("manifest.Implementation-Version=version1");
+        assertThat(entries.size(), is(4));
+
+        entries = list("manifest.Implementation-Version=version121");
+        assertThat(entries.size(), is(1));
+
+        entries = list("manifest.Implementation-revision=rev12");
+        assertThat(entries.size(), is(2));
+
+        entries = list("manifest.Implementation-Timestamp=2017_13");
+        assertThat(entries.size(), is(2));
+
+        entries = list("health=OK");
+        assertThat(entries.size(), is(5));
+
+        List<String> list = JacksonUtil.convertFromJson(rest.getJson(baseUrl + "/list?port=OK"), new TypeReference<List<String>>() {});
+        assertThat(list.size(), is(1));
+        assertThat(list.get(0), is("Bad Request: 'OK' is not a valid number."));
+
+        list = JacksonUtil.convertFromJson(rest.getJson(baseUrl + "/list?health=Suspended"), new TypeReference<List<String>>() {});
+        assertThat(list.size(), is(1));
+        assertThat(list.get(0), is("Bad Request: 'Suspended' is not valid, valid values are [OK, ERROR]"));
+    }
+
+    private List<RegisterEntry> list(String... parameters) {
+        String url = baseUrl + "/list?" + Stream.of(parameters).collect(joining("&"));
+        return JacksonUtil.convertFromJson(rest.getJson(url), new TypeReference<List<RegisterEntry>>() {});
+    }
+
+    private  void sendPing(String uuid, int port, String hostName, String module, String context, String target, int externalPort) {
         try {
-
+            RegisterEntry re = RegisterEntry.builder()
+                    .port(port)
+                    .hostname(hostName)
+                    .module(module)
+                    .context(context)
+                    .time(new Date())
+                    .uuid(uuid)
+                    .target(target)
+                    .externalPort(externalPort)
+                    .build();
+            re.getManifest().put("Implementation-revision", "rev" + uuid);
+            re.getManifest().put("Implementation-Version", "version" + uuid);
+            re.getManifest().put("Implementation-Timestamp", "2017_" + uuid);
             restAsync.post("http://localhost:8080/registry-app/service-registry/register",
-                           JacksonUtil.serializeToJson(entry))
-                     .join();
-        } catch (Exception e) {
-
-        }
+                           JacksonUtil.serializeToJson(re))
+                     .get();
+        } catch (Exception e) {}
     }
-
-    public static void main(String[] args) {
-        RegistryAppRunner appRunner = new RegistryAppRunner();
-        appRunner.startServer();
-    }
-
 }

--- a/micro-application-register/src/test/java/com/aol/micro/server/application/registry/CleanerTest.java
+++ b/micro-application-register/src/test/java/com/aol/micro/server/application/registry/CleanerTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertThat;
 import java.io.File;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -50,7 +51,7 @@ public class CleanerTest {
                                                 System.currentTimeMillis() - 2000)));
 
         cleaner.clean();
-        List<RegisterEntry> list = finder.find();
+        List<RegisterEntry> list = finder.find(Optional.empty());
         assertThat(list.size(), equalTo(0));
     }
 }

--- a/micro-application-register/src/test/java/com/aol/micro/server/application/registry/FinderTest.java
+++ b/micro-application-register/src/test/java/com/aol/micro/server/application/registry/FinderTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertThat;
 import java.io.File;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -44,7 +45,7 @@ public class FinderTest {
     @Test
     public void testFind() {
         writer.register(entry);
-        List<RegisterEntry> list = finder.find();
+        List<RegisterEntry> list = finder.find(Optional.empty());
         assertThat(list.size(), greaterThan(0));
         assertThat(list.get(0)
                        .getContext(),

--- a/micro-application-register/src/test/java/com/aol/micro/server/application/registry/RegisterEntryTest.java
+++ b/micro-application-register/src/test/java/com/aol/micro/server/application/registry/RegisterEntryTest.java
@@ -1,8 +1,10 @@
 package com.aol.micro.server.application.registry;
 
+import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Date;
+import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -15,14 +17,57 @@ public class RegisterEntryTest {
 
     @Before
     public void setUp() throws Exception {
-        entry = new RegisterEntry(
-                                  8080, "hostname", "name", "context", new Date(), null, 8080);
+        entry = RegisterEntry.builder()
+                .port(8080)
+                .hostname("host")
+                .module("module")
+                .context("context")
+                .time(new Date())
+                .uuid("1")
+                .target("target")
+                .externalPort(9090)
+                .build();
+        Map<String, String> manifest = entry.getManifest();
+        manifest.put("Implementation-revision", "a2edfe4bc");
+        manifest.put("Implementation-Version", "version");
+        manifest.put("Implementation-Timestamp", "2017_1201");
     }
 
     @Test
     public void test() {
+        assertTrue(JacksonUtil.serializeToJson(entry).contains("\"context\":\"context"));
+    }
 
-        assertTrue(JacksonUtil.serializeToJson(entry)
-                              .contains("\"context\":\"context"));
+    @Test
+    public void matches() throws Exception {
+        RegisterEntry re = new RegisterEntry();
+        re.getManifest().clear();
+        assertFalse(entry.matches(re));
+
+        re = RegisterEntry.builder().port(8080).externalPort(-1).build();
+        re.getManifest().clear();
+        assertTrue(entry.matches(re));
+
+        re = RegisterEntry.builder().port(8080).externalPort(9090).build();
+        re.getManifest().clear();
+        assertTrue(entry.matches(re));
+
+        re = RegisterEntry.builder().port(8080).hostname("host").externalPort(9090).build();
+        re.getManifest().clear();
+        assertTrue(entry.matches(re));
+
+        re = RegisterEntry.builder().port(8080).hostname("host1").externalPort(9090).build();
+        re.getManifest().clear();
+        assertFalse(entry.matches(re));
+
+        re = RegisterEntry.builder().port(8080).hostname("host").externalPort(9090).build();
+        re.getManifest().clear();
+        re.getManifest().put("Implementation-revision", "a2edfe4bc");
+        assertTrue(entry.matches(re));
+
+        re = RegisterEntry.builder().port(8080).hostname("host").externalPort(9090).build();
+        re.getManifest().clear();
+        re.getManifest().put("Implementation-Version", "version1");
+        assertFalse(entry.matches(re));
     }
 }

--- a/micro-application-register/src/test/java/com/aol/micro/server/application/registry/UriInfoParserTest.java
+++ b/micro-application-register/src/test/java/com/aol/micro/server/application/registry/UriInfoParserTest.java
@@ -1,0 +1,61 @@
+package com.aol.micro.server.application.registry;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.ws.rs.core.*;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
+public class UriInfoParserTest {
+
+    @Test
+    public void toRegisterEntryFromQueryParameters() throws Exception {
+        UriInfo uriInfo = Mockito.mock(UriInfo.class);
+        MultivaluedMap<String,String> data = new MultivaluedHashMap<>();
+        data.put("port", Arrays.asList("8080"));
+        data.put("externalPort", Arrays.asList("9090"));
+        data.put("hostname", Arrays.asList("host1"));
+        data.put("module", Arrays.asList("module1"));
+        data.put("context", Arrays.asList("context1"));
+        data.put("target", Arrays.asList("target1"));
+        data.put("health", Arrays.asList("OK"));
+        data.put("manifest.Implementation-revision", Arrays.asList("revision1"));
+        data.put("manifest.Implementation-Timestamp", Arrays.asList("2017_001"));
+        data.put("manifest.Implementation-Version", Arrays.asList("v1"));
+
+        when(uriInfo.getQueryParameters()).thenReturn(data);
+
+        Optional<RegisterEntry> reOptional = UriInfoParser.toRegisterEntry(uriInfo);
+        assertTrue(reOptional.isPresent());
+
+        RegisterEntry re = reOptional.get();
+        assertThat(re.getPort(), is(8080));
+        assertThat(re.getExternalPort(), is(9090));
+        assertThat(re.getHostname(), is("host1"));
+        assertThat(re.getModule(), is("module1"));
+        assertThat(re.getContext(), is("context1"));
+        assertThat(re.getTarget(), is("target1"));
+        assertThat(re.getHealth(), is(Health.OK));
+        assertThat(re.getManifest().get("Implementation-revision"), is("revision1"));
+        assertThat(re.getManifest().get("Implementation-Timestamp"), is("2017_001"));
+        assertThat(re.getManifest().get("Implementation-Version"), is("v1"));
+    }
+
+    @Test
+    public void toRegisterEntryFromEmptyQueryParameter() throws Exception {
+        UriInfo uriInfo = Mockito.mock(UriInfo.class);
+        when(uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>());
+
+        Optional<RegisterEntry> re = UriInfoParser.toRegisterEntry(uriInfo);
+        assertFalse(re.isPresent());
+
+    }
+}


### PR DESCRIPTION
Support filter functionality to `/list` endpoint.
Currently the following fields are supported.

- port
- externalPort
- hostname
- module
- context
- health
- manifest
  - Implementation-revision
  - Implementation-Timestamp
  - Implementation-Version

Sample Requests
```
/list?port=8080
/list?hostname=myhost
/list?health=ERROR&port=8080
```