### PR TITLE
Datadog report fix

### DIFF
--- a/micro-core/src/main/resources/logback.xml
+++ b/micro-core/src/main/resources/logback.xml
@@ -1,18 +1,10 @@
 <configuration scan="true">
 	
-
 	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
 		<encoder>
-			<pattern>%date{MMM dd yyyy h:mm:ss a z,EST} %-5p %c - %msg --
-				[%thread] %n</pattern>
+			<pattern>%date{MMM dd yyyy h:mm:ss a z,EST} %-5p %c - %msg -- [%thread] %n</pattern>
 		</encoder>
 	</appender>
-
-	
-
-	
-
-	
 
 	<root>
 		<level value="INFO" />


### PR DESCRIPTION
Removes that annoying missing `datadog.apikey` startup failure if apikey is not present during local test.

If apikey is not present, then it will just log the missing error in log file and ignore the datadog reporting