### PR TITLE
Using default java HostnameVerifier in RestClient

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.91.9
+version=0.91.10
 springVersion=4.3.3.RELEASE
 springBootVersion=1.4.1.RELEASE
 jerseyVersion=2.24

--- a/micro-client/src/main/java/com/aol/micro/server/rest/client/RestClient.java
+++ b/micro-client/src/main/java/com/aol/micro/server/rest/client/RestClient.java
@@ -7,6 +7,8 @@ import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
+import javax.net.ssl.HttpsURLConnection;
+
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -60,7 +62,7 @@ public class RestClient<T> {
 		clientConfig.property(ClientProperties.READ_TIMEOUT, rt);
 
 		ClientBuilder.newBuilder().register(JacksonFeature.class);
-		Client client = ClientBuilder.newClient(clientConfig);
+		Client client = ClientBuilder.newBuilder().withConfig(clientConfig).hostnameVerifier(HttpsURLConnection.getDefaultHostnameVerifier()).build();
 		client.register(JacksonFeature.class);
 		JacksonJaxbJsonProvider provider = new JacksonJaxbJsonProvider();
 		provider.setMapper(JacksonUtil.getMapper());


### PR DESCRIPTION
If default java HostnameVerifier get modified (for example by java agent), RestClient will continue to use its' own. This PR should fix it.