### PR TITLE
Change java indentation to 4 spaces.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,5 +10,8 @@ insert_final_newline = true
 indent_style = space
 indent_size = 2
 
+[*.java]
+indent_size = 4
+
 [*.md]
 trim_trailing_whitespace = false


### PR DESCRIPTION
Code Changes:
- _.editorconfig_ set as 4 spaces, no tabs, for java files.