### PR TITLE
Enable gzip compression for requests and responses on Jersey

### DIFF
--- a/micro-jersey/src/main/java/com/oath/micro/server/rest/jersey/JerseyRestApplication.java
+++ b/micro-jersey/src/main/java/com/oath/micro/server/rest/jersey/JerseyRestApplication.java
@@ -1,21 +1,21 @@
 package com.oath.micro.server.rest.jersey;
 
+import com.oath.micro.server.auto.discovery.Rest;
+import com.oath.micro.server.auto.discovery.RestResource;
+import com.oath.micro.server.module.JaxRsProvider;
+import com.oath.micro.server.servers.ServerThreadLocalVariables;
+import lombok.Getter;
+import org.glassfish.jersey.message.GZipEncoder;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.server.ServerProperties;
+import org.glassfish.jersey.server.filter.EncodingFilter;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Consumer;
-
-import lombok.Getter;
-
-import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.server.ServerProperties;
-
-import com.oath.micro.server.auto.discovery.Rest;
-import com.oath.micro.server.auto.discovery.RestResource;
-import com.oath.micro.server.module.JaxRsProvider;
-import com.oath.micro.server.servers.ServerThreadLocalVariables;
 
 public class JerseyRestApplication extends ResourceConfig {
 
@@ -51,6 +51,9 @@ public class JerseyRestApplication extends ResourceConfig {
 					register(next.getClass());
 			}
 		}
+
+		register(EncodingFilter.class); //Server encoding filter class
+		register(GZipEncoder.class);
 
 		register(new AsyncBinder());
 		

--- a/micro-jersey/src/test/java/com/oath/micro/server/rest/jersey/JerseyRestApplicationTest.java
+++ b/micro-jersey/src/test/java/com/oath/micro/server/rest/jersey/JerseyRestApplicationTest.java
@@ -10,6 +10,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.stream.Collectors;
 
+import org.glassfish.jersey.message.GZipEncoder;
+import org.glassfish.jersey.server.filter.EncodingFilter;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -54,8 +56,13 @@ public class JerseyRestApplicationTest {
 			assertThat(app.getApplication().getClasses().size(),is(1));
 			assertTrue(app.isRegistered(ServletStatusResource.class));
 		}
-		
-	
+
+    @Test
+    public void testGZipRegistration() {
+        JerseyRestApplication app = new JerseyRestApplication();
+        assertTrue(app.isRegistered(GZipEncoder.class));
+        assertTrue(app.isRegistered(EncodingFilter.class));
+    }
 
 	
 


### PR DESCRIPTION
This change will enable that modules using micro-jersey plugin can use gzip compression on the request and responses making use of Accept-Encoding and Content-Encoding with "gzip" value.


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
